### PR TITLE
Implemented a "terms form type"

### DIFF
--- a/DependencyInjection/SymfonyCmfRoutingExtraExtension.php
+++ b/DependencyInjection/SymfonyCmfRoutingExtraExtension.php
@@ -52,6 +52,10 @@ class SymfonyCmfRoutingExtraExtension extends Extension
         foreach ($config['chain']['routers_by_id'] as $id => $priority) {
             $router->addMethodCall('add', array(new Reference($id), $priority));
         }
+
+        $loader->load('form_type.xml');
+        $resources = $container->getParameter('twig.form.resources');
+        $container->setParameter('twig.form.resources',array_merge(array('SymfonyCmfRoutingExtraBundle:Form:terms_form_type.html.twig'), $resources));
     }
 
     /**

--- a/Form/Type/TermsFormType.php
+++ b/Form/Type/TermsFormType.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\RoutingExtraBundle\Form\Type;
+
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormViewInterface;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * Form type for rendering a checkbox with a label that can contain links to pages
+ *
+ * Usage: supply an array with content_ids with the form type options. The form type will generate the
+ * urls using the router and replace the array keys from the content_ids array with the urls in the form types label
+ *
+ * A typical use case is a checkbox the user needs to check to accept terms that are on a different page that has a
+ * dynamic route.
+ *
+ * @author Uwe Jäger <uwej711@googlemail.com>
+ */
+class TermsFormType extends AbstractType
+{
+    protected $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->setAttribute('content_ids', $options['content_ids']);
+        parent::buildForm($builder, $options);
+    }
+
+    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
+    {
+        $contentIds = $form->getAttribute('content_ids');
+        $paths = array();
+        foreach ($contentIds as $key => $id) {
+            $paths[$key] = $this->router->generate('cmf_routing_doctrine_route', array('content_id' => $id));
+        }
+        $view->setVar('content_paths', $paths);
+        parent::buildView($view, $form, $options);
+    }
+
+    public function getDefaultOptions()
+    {
+        return array('content_ids' => array());
+    }
+
+    /**
+     * Returns the name of this type.
+     *
+     * @return string The name of this type
+     */
+    public function getName()
+    {
+        return 'symfony_cmf_routing_extra_terms_form_type';
+    }
+
+    public function getParent()
+    {
+        return 'checkbox';
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ The possible mappings are (in order of precedence):
 To see some examples, please look at the [cmf-sandbox](https://github.com/symfony-cmf/cmf-sandbox)
 and specifically the routing fixtures loading.
 
+## Form Type
+
+The bundle defines a form type that can be used for classical "accept terms" checkboxes where you place urls in the label. Simply
+specify `symfony_cmf_routing_extra_terms_form_type` as the form type name and specify a label and an array with content_ids in the options:
+```
+add('terms', 'symfony_cmf_routing_extra_terms_form_type', array(
+    'label' => 'I have seen the <a href="%team%">Team</a> and <a href="%more%">More</a> pages ...',
+    'content_ids' => array('%team%' => '/cms/content/static/team', '%more%' => '/cms/content/static/more')
+))
+```
+The form type automatically generates the routes for the specified content and passes the routes to the trans twig helper for replacement
+in the label. 
 
 ### Further notes
 
@@ -217,4 +229,5 @@ extend it. You can also write your own routers to hook into the chain.
 * Claudio Beatrice (omissis)
 * Lukas Kahwe Smith (lsmith77)
 * David Buchmann (dbu)
+* Uwe Jäger (uwej711)
 * [And others](https://github.com/symfony-cmf/RoutingExtraBundle/contributors)

--- a/Resources/config/form_type.xml
+++ b/Resources/config/form_type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="symfony_cmf_routing_extra.terms_form_type_class">Symfony\Cmf\Bundle\RoutingExtraBundle\Form\Type\TermsFormType</parameter>
+    </parameters>
+
+    <services>
+
+        <service id="symfony_cmf_routing_extra.terms_form_type" class="%symfony_cmf_routing_extra.terms_form_type_class%">
+            <tag name="form.type" alias="symfony_cmf_routing_extra_terms_form_type" />
+            <argument type="service" id="router" />
+        </service>
+
+    </services>
+</container>

--- a/Resources/views/Form/terms_form_type.html.twig
+++ b/Resources/views/Form/terms_form_type.html.twig
@@ -1,0 +1,8 @@
+{% block symfony_cmf_routing_extra_terms_form_type_row %}
+{% spaceless %}
+<label class="checkbox">
+    <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+    {{ label | trans(content_paths, translation_domain) | raw }}
+</label>
+{% endspaceless %}
+{% endblock %}


### PR DESCRIPTION
The terms form type can be used to add checkboxes with labels containing
links to your document pages (e.g. your terms page) to your forms.

See the README and the sandbox (Demo/Explicit Controller) for an example.
