### PR TITLE
use attached content to find a route that matches a required locale

### DIFF
--- a/Document/RouteRepository.php
+++ b/Document/RouteRepository.php
@@ -145,7 +145,32 @@ class RouteRepository implements RouteRepositoryInterface
             throw new RouteNotFoundException("No route found for name '$name'");
         }
 
+        if (!$this->checkLocaleRequirement($route, $parameters)) {
+            $content = $route->getRouteContent();
+            if ($content) {
+                $routes = $content->getRoutes();
+                foreach ($routes as $contentRoute) {
+                    if ($this->checkLocaleRequirement($contentRoute, $parameters)) {
+                        return $contentRoute;
+                    }
+                }
+            }
+        }
+
         return $route;
+    }
+
+    /**
+     * @param Route $route
+     * @param array $parameters
+     * @return bool TRUE if there is either no _locale, no _locale requirement or if the two match
+     */
+    private function checkLocaleRequirement(Route $route, array $parameters)
+    {
+        return empty($parameters['_locale'])
+            || !$route->getRequirement('_locale')
+            || preg_match('/'.$route->getRequirement('_locale').'/', $parameters['_locale'])
+        ;
     }
 
     public function setRouteNamePrefix($routeNamePrefix)


### PR DESCRIPTION
if the route specificed by a name does not match the locale, see if there is a route on the content that does (fixes #22)

just a first stab ..
see here for a real world use:
https://github.com/symfony-cmf/cmf-sandbox/pull/131/files#L3R6
