### PR TITLE
fix tests which broke since DynamicRouter::generate() refactoring

### DIFF
--- a/Controller/RedirectController.php
+++ b/Controller/RedirectController.php
@@ -43,7 +43,13 @@ class RedirectController
         $url = $contentDocument->getUri();
 
         if (empty($url)) {
-            $url = $this->router->generate($contentDocument->getRouteName(), $contentDocument->getParameters(), true);
+            $routeTarget = $contentDocument->getRouteTarget();
+            if ($routeTarget) {
+                $url = $this->router->generate($routeTarget, $contentDocument->getParameters(), true);
+            } else {
+                $routeName = $contentDocument->getRouteName();
+                $url = $this->router->generate($routeName, $contentDocument->getParameters(), true);
+            }
         }
 
         return new RedirectResponse($url, $contentDocument->isPermanent() ? 301 : 302);

--- a/Document/RedirectRoute.php
+++ b/Document/RedirectRoute.php
@@ -59,15 +59,7 @@ class RedirectRoute extends Route implements RedirectRouteInterface
     }
 
     /**
-     * Get the target route document this route redirects to.
-     *
-     * If non-null, it is added as route into the parameters, which will lead
-     * to have the generate call issued by the RedirectController to have
-     * the target route in the parameters.
-     *
-     * @return RouteObjectInterface the route this redirection points to
-     *
-     * @see getParameters
+     * {@inheritDoc}
      */
     public function getRouteTarget()
     {
@@ -122,11 +114,6 @@ class RedirectRoute extends Route implements RedirectRouteInterface
         $parameters = $this->parameters;
         if ($parameters instanceof Collection) {
             $parameters = $parameters->toArray();
-        }
-
-        $route = $this->getRouteTarget();
-        if (!empty($route)) {
-            $parameters['route'] = $route;
         }
 
         return $parameters;

--- a/Tests/Functional/Document/RedirectRouteTest.php
+++ b/Tests/Functional/Document/RedirectRouteTest.php
@@ -41,8 +41,7 @@ class RedirectRouteTest extends BaseTestCase
         $this->assertInstanceOf('Symfony\\Cmf\\Component\\Routing\\RedirectRouteInterface', $redirect);
         $this->assertSame($redirect, $redirect->getRouteContent());
         $params = $redirect->getParameters();
-        $this->assertArrayHasKey('route', $params);
-        $this->assertSame($route, $params['route']);
+        $this->assertSame($route, $redirect->getRouteTarget());
         $defaults = $redirect->getDefaults();
         $this->assertEquals(array('test' => 'toast'), $defaults);
     }

--- a/Tests/Functional/Routing/DynamicRouterTest.php
+++ b/Tests/Functional/Routing/DynamicRouterTest.php
@@ -147,14 +147,14 @@ class DynamicRouterTest extends BaseTestCase
     {
         $route = self::$dm->find(null, self::ROUTE_ROOT.'/testroute/child');
 
-        $url = self::$router->generate('', array('route' => $route, 'test' => 'value'));
+        $url = self::$router->generate($route, array('test' => 'value'));
         $this->assertEquals('/testroute/child?test=value', $url);
     }
 
     public function testGenerateAbsolute()
     {
         $route = self::$dm->find(null, self::ROUTE_ROOT.'/testroute/child');
-        $url = self::$router->generate('', array('route' => $route, 'test' => 'value'), true);
+        $url = self::$router->generate($route, array('test' => 'value'), true);
         $this->assertEquals('http://localhost/testroute/child?test=value', $url);
     }
 
@@ -162,7 +162,7 @@ class DynamicRouterTest extends BaseTestCase
     {
         $route = self::$dm->find(null, self::ROUTE_ROOT.'/testroute');
 
-        $url = self::$router->generate('', array('route' => $route, 'slug' => 'gen-slug', 'test' => 'value'));
+        $url = self::$router->generate($route, array('slug' => 'gen-slug', 'test' => 'value'));
         $this->assertEquals('/testroute/gen-slug?test=value', $url);
     }
 
@@ -173,14 +173,14 @@ class DynamicRouterTest extends BaseTestCase
     {
         $route = self::$dm->find(null, self::ROUTE_ROOT.'/testroute');
 
-        self::$router->generate('', array('route' => $route, 'slug' => 'gen-slug', 'id' => 'nonumber'));
+        self::$router->generate($route, array('slug' => 'gen-slug', 'id' => 'nonumber'));
     }
 
     public function testGenerateDefaultFormat()
     {
         $route = self::$dm->find(null, self::ROUTE_ROOT.'/format');
 
-        $url = self::$router->generate('', array('route' => $route, 'id' => 37));
+        $url = self::$router->generate($route, array('id' => 37));
         $this->assertEquals('/format/37', $url);
     }
 
@@ -188,7 +188,7 @@ class DynamicRouterTest extends BaseTestCase
     {
         $route = self::$dm->find(null, self::ROUTE_ROOT.'/format');
 
-        $url = self::$router->generate('', array('route' => $route, 'id' => 37, '_format' => 'json'));
+        $url = self::$router->generate($route, array('id' => 37, '_format' => 'json'));
         $this->assertEquals('/format/37.json', $url);
     }
 
@@ -199,6 +199,6 @@ class DynamicRouterTest extends BaseTestCase
     {
         $route = self::$dm->find(null, self::ROUTE_ROOT.'/format');
 
-        self::$router->generate('', array('route' => $route, 'id' => 37, '_format' => 'xyz'));
+        self::$router->generate($route, array('id' => 37, '_format' => 'xyz'));
     }
 }


### PR DESCRIPTION
'route' is no longer supported as a parameter in DynamicRouter::generate()
