### PR TITLE
support hostnamePattern, have default locale for CLI / test situation

### DIFF
--- a/Document/Route.php
+++ b/Document/Route.php
@@ -47,6 +47,14 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     protected $idPrefix;
 
     /**
+     * @since Symfony 2.2 introduces the host name pattern. This default
+     * implementation just stores it as a field.
+     *
+     * @var string
+     */
+    protected $hostnamePattern = '';
+
+    /**
      * Variable pattern part. The static part of the pattern is the id without the prefix.
      */
     protected $variablePattern;
@@ -105,6 +113,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     public function setParent($parent)
     {
         $this->parent = $parent;
+        return $this;
     }
 
     public function getParent()
@@ -122,6 +131,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     public function setName($name)
     {
         $this->name = $name;
+        return $this;
     }
 
     public function getName()
@@ -138,6 +148,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     {
         $this->parent = $parent;
         $this->name = $name;
+        return $this;
     }
 
     /**
@@ -151,6 +162,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     public function setPath($path)
     {
         $this->path = $path;
+        return $this;
     }
 
     public function getPrefix()
@@ -161,6 +173,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     public function setPrefix($idPrefix)
     {
         $this->idPrefix = $idPrefix;
+        return $this;
     }
 
     /**
@@ -195,6 +208,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     public function setRouteContent($document)
     {
         $this->routeContent = $document;
+        return $this;
     }
 
     /**
@@ -203,6 +217,23 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     public function getRouteContent()
     {
         return $this->routeContent;
+    }
+
+    /**
+     * Hide the core hostname pattern
+     */
+    public function setHostnamePattern($pattern)
+    {
+        $this->hostnamePattern = $pattern;
+        return $this;
+    }
+
+    /**
+     * Hide the core hostname pattern
+     */
+    public function getHostnamePattern()
+    {
+        return $this->hostnamePattern;
     }
 
     /**
@@ -252,6 +283,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     {
         $this->variablePattern = $variablePattern;
         $this->needRecompile = true;
+        return $this;
     }
 
     /**

--- a/Resources/config/doctrine/Route.phpcr.xml
+++ b/Resources/config/doctrine/Route.phpcr.xml
@@ -9,6 +9,7 @@
         </id>
         <reference-one fieldName="routeContent"/>
         <children fieldName="children"/>
+        <field fieldName="hostnamePattern" type="string"/>
         <field fieldName="variablePattern" type="string"/>
         <field fieldName="defaults" type="string" assoc=""/>
         <field fieldName="requirements" type="string" assoc=""/>

--- a/Routing/DynamicRouter.php
+++ b/Routing/DynamicRouter.php
@@ -45,6 +45,11 @@ class DynamicRouter extends BaseDynamicRouter implements ContainerAwareInterface
      */
     protected $container;
 
+    /**
+     * @var string
+     */
+    protected $defaultLocale = null;
+
     public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;
@@ -84,6 +89,17 @@ class DynamicRouter extends BaseDynamicRouter implements ContainerAwareInterface
         return $request;
     }
 
+    /**
+     * Overwrite the locale to be used by default if there is neither one in
+     * the parameters when building the route nor a request available (i.e. CLI).
+     *
+     * @param string $locale
+     */
+    public function setDefaultLocale($locale)
+    {
+        $this->defaultLocale = $locale;
+    }
+
     protected function getLocale($parameters)
     {
         $locale = parent::getLocale($parameters);
@@ -91,8 +107,11 @@ class DynamicRouter extends BaseDynamicRouter implements ContainerAwareInterface
             return $locale;
         }
 
-        if (is_null($this->container) || ! $request = $this->container->get('request')) {
-            throw new \RuntimeException('Request object not available from container');
+        if (is_null($this->container)
+            || ! $this->container->isScopeActive('request')
+            || ! $request = $this->container->get('request')
+        ) {
+            return $this->defaultLocale;
         }
 
         return $request->getLocale();

--- a/Tests/Functional/Routing/DynamicRouterTest.php
+++ b/Tests/Functional/Routing/DynamicRouterTest.php
@@ -82,7 +82,7 @@ class DynamicRouterTest extends BaseTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Routing\Exception\ResourceNotFoundException
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
      */
     public function testNoMatch()
     {
@@ -90,7 +90,7 @@ class DynamicRouterTest extends BaseTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Routing\Exception\MethodNotAllowedException
+     * @expectedException \Symfony\Component\Routing\Exception\MethodNotAllowedException
      */
     public function testNotAllowed()
     {
@@ -135,7 +135,7 @@ class DynamicRouterTest extends BaseTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Routing\Exception\ResourceNotFoundException
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
      */
     public function testNoMatchingFormat()
     {
@@ -166,7 +166,7 @@ class DynamicRouterTest extends BaseTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Routing\Exception\InvalidParameterException
+     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
      */
     public function testGenerateParametersInvalid()
     {
@@ -192,7 +192,7 @@ class DynamicRouterTest extends BaseTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Routing\Exception\InvalidParameterException
+     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
      */
     public function testGenerateNoMatchingFormat()
     {

--- a/Tests/Routing/DynamicRouterTest.php
+++ b/Tests/Routing/DynamicRouterTest.php
@@ -32,10 +32,15 @@ class DynamicRouterTest extends BaseDynamicRouterTest
     }
 
     /**
-     * @expectedException Symfony\Component\Routing\Exception\RouteNotFoundException
+     * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
      */
     public function testGenerateInvalidRoute()
     {
+        $this->container->expects($this->once())
+            ->method('isScopeActive')
+            ->with('request')
+            ->will($this->returnValue(true)
+        );
         $this->container->expects($this->once())
             ->method('get')
             ->with('request')
@@ -46,6 +51,11 @@ class DynamicRouterTest extends BaseDynamicRouterTest
 
     public function testGenerateNoRequest()
     {
+        $this->container->expects($this->once())
+            ->method('isScopeActive')
+            ->with('request')
+            ->will($this->returnValue(true)
+        );
         $this->container->expects($this->once())
             ->method('get')
             ->with('request')


### PR DESCRIPTION
BC break: Routes now have a new field hostnamePattern. 

with symfony 2.1 this will do nothing afaik, but 2.2 will use it to do multihost-routing. if we do not handle this, we return null as hostnamePattern which fails the route compiler as it checks '' !== pattern and null is not exactly an empty string.

some future work could be: 
- support a route tree where we get the hostname from a tree element, allowing to use a route tree per host handled by this site
- figure a way how we actually set the default route when in CLI mode. right now we will get random locales when we have separate routes per locale
