### PR TITLE
removed evil hacks to persist defaults/requirements/options

### DIFF
--- a/DependencyInjection/Compiler/RoutePass.php
+++ b/DependencyInjection/Compiler/RoutePass.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\RoutingExtraBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * A CompilerPass which registers the mapping file for the core Route class
+ *
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class RoutePass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('symfony_cmf_routing_extra.manager_registry')) {
+            return;
+        }
+
+        $managerRegistry = $container->getDefinition('symfony_cmf_routing_extra.manager_registry');
+        $managerName = $managerRegistry->getArgument(0);
+        $chainDriverDefService = sprintf('doctrine_phpcr.odm.%s_metadata_driver', $managerName);
+        if (!$container->hasDefinition($chainDriverDefService)) {
+            return;
+        }
+
+        $mappingService = 'symfony_cmf_routing_extra.phpcr_mapping.core_route';
+        $arguments = array('Symfony\Component\Routing' => realpath(__DIR__.'/../../Resources/config/doctrine'));
+        $mappingDriverDef = new Definition('Doctrine\ODM\PHPCR\Mapping\Driver\XmlDriver', $arguments);
+        $container->setDefinition($mappingService, $mappingDriverDef);
+
+        $chainDriverDef = $container->getDefinition($chainDriverDefService);
+        $chainDriverDef->addMethodCall('addDriver', array(new Reference($mappingService), 'Symfony\Component\Routing'));
+    }
+}
+

--- a/Document/Route.php
+++ b/Document/Route.php
@@ -75,21 +75,6 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     protected $variablePattern;
 
     /**
-     * @var \Doctrine\ODM\PHPCR\MultivaluePropertyCollection|array
-     */
-    protected $defaults = array();
-
-    /**
-     * @var \Doctrine\ODM\PHPCR\MultivaluePropertyCollection|array
-     */
-    protected $requirements = array();
-
-    /**
-     * @var \Doctrine\ODM\PHPCR\MultivaluePropertyCollection|array
-     */
-    protected $options = array();
-
-    /**
      * @var Boolean
      */
     protected $needRecompile = false;
@@ -109,13 +94,12 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      */
     public function __construct($addFormatPattern = false)
     {
-        $this->postLoad();
-
         $this->addFormatPattern = $addFormatPattern;
         if ($this->addFormatPattern) {
             $this->setDefault('_format', 'html');
             $this->setRequirement('_format', 'html');
         }
+        $this->setOptions(array());
     }
 
     /**
@@ -321,56 +305,6 @@ class Route extends SymfonyRoute implements RouteObjectInterface
             parent::setPattern($this->getStaticPrefix() . $this->getVariablePattern());
         }
         return parent::compile();
-    }
-
-    /**
-     * copy defaults/requirements/options to the parent class
-     */
-    public function postLoad()
-    {
-        $defaults = $this->defaults instanceof Collection
-            ? $this->defaults->toArray() : (array)$this->defaults;
-        $this->setDefaults($defaults);
-
-        $requirements = $this->requirements instanceof Collection
-            ? $this->requirements->toArray() : (array)$this->requirements;
-        $this->setRequirements($requirements);
-
-        $options = $this->options instanceof Collection
-            ? $this->options->toArray() : (array)$this->options;
-        $this->setOptions($options);
-    }
-
-    /**
-     * copy defaults/requirements/options from the parent class
-     */
-    public function preStorage()
-    {
-        $defaults = parent::getDefaults();
-        $oldDefaults = $this->defaults instanceof Collection
-            ? $this->defaults->toArray() : $this->defaults;
-        if ($defaults !== $oldDefaults) {
-            $this->defaults = $defaults;
-        }
-
-        $requirements = parent::getRequirements();
-        $oldRequirements = $this->requirements instanceof Collection
-            ? $this->requirements->toArray() : $this->requirements;
-        if ($requirements !== $oldRequirements) {
-            $this->requirements = $requirements;
-        }
-
-        $options = parent::getOptions();
-        // avoid storing the default value for the compiler, in case this ever changes in code
-        // would be nice if those where class constants of the symfony route instead of hardcoded strings
-        if ('Symfony\\Component\\Routing\\RouteCompiler' == $options['compiler_class']) {
-            unset($options['compiler_class']);
-        }
-        $oldOptions = $this->options instanceof Collection
-            ? $this->options->toArray() : $this->options;
-        if ($options !== $oldOptions) {
-            $this->options = $options;
-        }
     }
 
     public function __toString()

--- a/Resources/config/doctrine/Route.phpcr.xml
+++ b/Resources/config/doctrine/Route.phpcr.xml
@@ -11,16 +11,7 @@
         <children fieldName="children"/>
         <field fieldName="hostnamePattern" type="string"/>
         <field fieldName="variablePattern" type="string"/>
-        <field fieldName="defaults" type="string" assoc=""/>
-        <field fieldName="requirements" type="string" assoc=""/>
-        <field fieldName="options" type="string" assoc=""/>
         <field fieldName="addFormatPattern" type="boolean"/>
-
-        <lifecycle-callbacks>
-            <lifecycle-callback method="postLoad" type="postLoad"/>
-            <lifecycle-callback method="preStorage" type="prePersist"/>
-            <lifecycle-callback method="preStorage" type="preUpdate"/>
-        </lifecycle-callbacks>
     </document>
 
 </doctrine-mapping>

--- a/Resources/config/doctrine/Symfony.Component.Routing.Route.dcm.xml
+++ b/Resources/config/doctrine/Symfony.Component.Routing.Route.dcm.xml
@@ -1,0 +1,10 @@
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/phpcr/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <mapped-superclass name="Symfony\Component\Routing\Route">
+        <field fieldName="defaults" type="string" assoc=""/>
+        <field fieldName="requirements" type="string" assoc=""/>
+        <field fieldName="options" type="string" assoc=""/>
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/SymfonyCmfRoutingExtraBundle.php
+++ b/SymfonyCmfRoutingExtraBundle.php
@@ -7,6 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Cmf\Bundle\RoutingExtraBundle\DependencyInjection\Compiler\ChainRouterPass;
 use Symfony\Cmf\Bundle\RoutingExtraBundle\DependencyInjection\Compiler\MapperPass;
 use Symfony\Cmf\Bundle\RoutingExtraBundle\DependencyInjection\Compiler\SetRouterPass;
+use Symfony\Cmf\Bundle\RoutingExtraBundle\DependencyInjection\Compiler\RoutePass;
 
 /**
  * Bundle class
@@ -22,5 +23,6 @@ class SymfonyCmfRoutingExtraBundle extends Bundle
         $container->addCompilerPass(new ChainRouterPass());
         $container->addCompilerPass(new MapperPass());
         $container->addCompilerPass(new SetRouterPass());
+        $container->addCompilerPass(new RoutePass());
     }
 }


### PR DESCRIPTION
by mapping the core Route as a mapped-superclass

requires support for native arrays for multivalue properties in PHPCR ODM:
https://github.com/doctrine/phpcr-odm/pull/192
