### PR TITLE
replace the router alias in a compiler pass

### DIFF
--- a/DependencyInjection/Compiler/SetRouterPass.php
+++ b/DependencyInjection/Compiler/SetRouterPass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\RoutingExtraBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Changes the Router implementation.
+ *
+ */
+class SetRouterPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+
+        // only replace the default router by overwriting the 'router' alias if config tells us to
+        if (true === $container->getParameter('symfony_cmf_routing_extra.replace_symfony_router')) {
+            $container->setAlias('router', 'symfony_cmf_routing_extra.router');
+        }
+
+    }
+}

--- a/DependencyInjection/SymfonyCmfRoutingExtraExtension.php
+++ b/DependencyInjection/SymfonyCmfRoutingExtraExtension.php
@@ -35,10 +35,7 @@ class SymfonyCmfRoutingExtraExtension extends Extension
 
         /* set up the chain router */
         $loader->load('chain_routing.xml');
-        // only replace the default router by overwriting the 'router' alias if config tells us to
-        if ($config['chain']['replace_symfony_router']) {
-            $container->setAlias('router', $this->getAlias() . '.router');
-        }
+        $container->setParameter($this->getAlias() . '.replace_symfony_router', $config['chain']['replace_symfony_router']);
 
         // add the routers defined in the configuration mapping
         $router = $container->getDefinition($this->getAlias() . '.router');

--- a/SymfonyCmfRoutingExtraBundle.php
+++ b/SymfonyCmfRoutingExtraBundle.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Cmf\Bundle\RoutingExtraBundle\DependencyInjection\Compiler\ChainRouterPass;
 use Symfony\Cmf\Bundle\RoutingExtraBundle\DependencyInjection\Compiler\MapperPass;
+use Symfony\Cmf\Bundle\RoutingExtraBundle\DependencyInjection\Compiler\SetRouterPass;
 
 /**
  * Bundle class
@@ -20,5 +21,6 @@ class SymfonyCmfRoutingExtraBundle extends Bundle
         parent::build($container);
         $container->addCompilerPass(new ChainRouterPass());
         $container->addCompilerPass(new MapperPass());
+        $container->addCompilerPass(new SetRouterPass());
     }
 }

--- a/Tests/DependencyInjection/Compiler/SetRouterPassTest.php
+++ b/Tests/DependencyInjection/Compiler/SetRouterPassTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\RoutingExtraBundle\Tests\DependencyInjection\Compiler;
+
+use Symfony\Cmf\Bundle\RoutingExtraBundle\DependencyInjection\Compiler\SetRouterPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class SetRouterPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testMapperPassReplacesRouterAlias()
+    {
+        $pass = new SetRouterPass();
+
+        $builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $builder->expects($this->once())
+            ->method('getParameter')
+            ->with('symfony_cmf_routing_extra.replace_symfony_router')
+            ->will($this->returnValue(true));
+        $builder->expects($this->once())
+            ->method('setAlias')
+            ->with('router', 'symfony_cmf_routing_extra.router');
+
+        $pass->process($builder);
+    }
+
+    public function testMapperPassDoesntReplaceRouterAlias()
+    {
+        $pass = new SetRouterPass();
+
+        $builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $builder->expects($this->once())
+            ->method('getParameter')
+            ->with('symfony_cmf_routing_extra.replace_symfony_router')
+            ->will($this->returnValue(false));
+        $builder->expects($this->never())
+            ->method('setAlias');
+
+        $pass->process($builder);
+    }
+}

--- a/Tests/DependencyInjection/SymfonyCmfRoutingExtraExtensionTest.php
+++ b/Tests/DependencyInjection/SymfonyCmfRoutingExtraExtensionTest.php
@@ -42,9 +42,7 @@ class SymfonyCmfRoutingExtraExtensionTest extends \PHPUnit_Framework_TestCase
         $alias = $builder->getAlias('symfony_cmf_routing_extra.content_repository');
         $this->assertEquals('symfony_cmf_routing_extra.default_content_repository', $alias->__toString());
 
-        $this->assertTrue($builder->hasAlias('router'));
-        $alias = $builder->getAlias('router');
-        $this->assertEquals('symfony_cmf_routing_extra.router', $alias->__toString());
+        $this->assertTrue($builder->getParameter('symfony_cmf_routing_extra.replace_symfony_router'));
 
         $this->assertTrue($builder->hasDefinition('symfony_cmf_routing_extra.router'));
         $methodCalls = $builder->getDefinition('symfony_cmf_routing_extra.router')->getMethodCalls();


### PR DESCRIPTION
This fixes the issue discussed in #36.
This PR makes the bundle compatible with JMSI18nRoutingBundle.

Thanks
