### PR TITLE
make it possible to set a trailing slash in the pattern

### DIFF
--- a/Document/Route.php
+++ b/Document/Route.php
@@ -89,18 +89,26 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     protected $addFormatPattern;
 
     /**
+     * if to add "/" to the pattern
+     *
+     * @var Boolean
+     */
+    protected $addTrailingSlash;
+
+    /**
      * Overwrite to be able to create route without pattern
      *
      * @param Boolean $addFormatPattern if to add ".{_format}" to the route pattern
      *                                  also implicitly sets a default/require on "_format" to "html"
      */
-    public function __construct($addFormatPattern = false)
+    public function __construct($addFormatPattern = false, $addTrailingSlash = false)
     {
         $this->addFormatPattern = $addFormatPattern;
         if ($this->addFormatPattern) {
             $this->setDefault('_format', 'html');
             $this->setRequirement('_format', 'html');
         }
+        $this->addTrailingSlash = $addTrailingSlash;
     }
 
     /**
@@ -298,6 +306,9 @@ class Route extends SymfonyRoute implements RouteObjectInterface
         $pattern = $this->getStaticPrefix() . $this->getVariablePattern();
         if ($this->addFormatPattern && !preg_match('/(.+)\.[a-z]+$/i', $pattern, $matches)) {
             $pattern .= '.{_format}';
+        };
+        if ($this->addTrailingSlash && '/' !== $pattern[strlen($pattern)-1]) {
+            $pattern .= '/';
         };
         return $pattern;
     }

--- a/Resources/config/doctrine/Route.phpcr.xml
+++ b/Resources/config/doctrine/Route.phpcr.xml
@@ -12,6 +12,7 @@
         <field fieldName="hostnamePattern" type="string"/>
         <field fieldName="variablePattern" type="string"/>
         <field fieldName="addFormatPattern" type="boolean"/>
+        <field fieldName="addTrailingSlash" type="boolean"/>
     </document>
 
 </doctrine-mapping>


### PR DESCRIPTION
this however requires using https://github.com/symfony/Routing/blob/master/Matcher/RedirectableUrlMatcher.php as the url matcher .. in the 1.0.0-alpha2 `DynamicRouter` the url matcher was hardcoded, in the refactored version its no longer hardcoded, but it introduces a new matcher that extends from the core UrlMatcher.

see https://github.com/symfony-cmf/Routing/pull/34#discussion_r2379745
