### PR TITLE
Move minimal route admin to top

### DIFF
--- a/Resources/config/routing-extra-admin.xml
+++ b/Resources/config/routing-extra-admin.xml
@@ -11,6 +11,26 @@
     </parameters>
 
     <services>
+
+        <service id="symfony_cmf_routing_extra.minimal_route_admin" class="%symfony_cmf_routing_extra.minimal_route_admin_class%">
+            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="dashboard.group_routing" label_catalogue="SymfonyCmfRoutingExtraBundle" label="dashboard.label_minimal_routing" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument/>
+            <argument>Symfony\Cmf\Bundle\RoutingExtraBundle\Document\Route</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+
+            <call method="setContentRoot">
+                <argument>%symfony_cmf_routing_extra.content_basepath%</argument>
+            </call>
+
+            <call method="setRouteRoot">
+                <argument>%symfony_cmf_routing_extra.route_basepath%</argument>
+            </call>
+        </service>
+
         <service id="symfony_cmf_routing_extra.route_admin" class="%symfony_cmf_routing_extra.route_admin_class%">
             <tag name="sonata.admin" manager_type="doctrine_phpcr" group="dashboard.group_routing" label_catalogue="SymfonyCmfRoutingExtraBundle" label="dashboard.label_routing" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument/>
@@ -38,25 +58,6 @@
 
             <call method="setRouteBuilder">
                 <argument type="service" id="sonata.admin.route.path_info_slashes" />
-            </call>
-
-            <call method="setRouteRoot">
-                <argument>%symfony_cmf_routing_extra.route_basepath%</argument>
-            </call>
-        </service>
-
-        <service id="symfony_cmf_routing_extra.minimal_route_admin" class="%symfony_cmf_routing_extra.minimal_route_admin_class%">
-            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="dashboard.group_routing" label_catalogue="SymfonyCmfRoutingExtraBundle" label="dashboard.label_minimal_routing" label_translator_strategy="sonata.admin.label.strategy.underscore" />
-            <argument/>
-            <argument>Symfony\Cmf\Bundle\RoutingExtraBundle\Document\Route</argument>
-            <argument>SonataAdminBundle:CRUD</argument>
-
-            <call method="setRouteBuilder">
-                <argument type="service" id="sonata.admin.route.path_info_slashes" />
-            </call>
-
-            <call method="setContentRoot">
-                <argument>%symfony_cmf_routing_extra.content_basepath%</argument>
             </call>
 
             <call method="setRouteRoot">


### PR DESCRIPTION
Hi,

When clicking a route in the dashboard tree, we are redirected to the `minimal route admin`.

This is because the `minimal route admin` is declared **after** the `route admin`, and getAdminByClass() returns the last registered one for a given class (see https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/master/Tree/PhpcrOdmTree.php#L213)

This PR is not really a fix but a workaround, as it simply moves the `minimal route admin` up in the config file.
