### PR TITLE
Re-added getPattern method

### DIFF
--- a/Document/Route.php
+++ b/Document/Route.php
@@ -387,6 +387,11 @@ class Route extends SymfonyRoute implements RouteObjectInterface
         return $children;
     }
 
+    public function getPattern()
+    {
+        return $this->getPath();
+    }
+
     public function __toString()
     {
         return (string) $this->name;


### PR DESCRIPTION
Not sure what was intended here, but the reason the tests are failing is because the [get|set]Pattern methods were removed somewhere along the line.
