### PR TITLE
provide route collection hierarchy

### DIFF
--- a/Tests/Document/RouteProviderTest.php
+++ b/Tests/Document/RouteProviderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\RoutingExtraBundle\Tests\Document;
+
+use Symfony\Cmf\Bundle\RoutingBundle\Document\Route;
+use Symfony\Cmf\Bundle\RoutingBundle\Document\RouteProvider;
+
+class RouteProviderTest extends \PHPUnit_Framework_Testcase
+{
+    protected $routeProvider;
+
+    public function setUp()
+    {
+        $dm = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->routeProvider = new RouteProvider($dm);
+    }
+
+    public function testGetRouteCollectionForNode()
+    {
+        $routeCollection = $this->routeProvider->getRouteCollectionForHierarchy($this->generateRouteHierarchy());
+        $this->assertInstanceOf('\Symfony\Component\Routing\RouteCollection', $routeCollection);
+        $this->assertEquals(3, $routeCollection->count());
+    }
+
+    /**
+     * @return \Symfony\Cmf\Bundle\RoutingExtraBundle\Document\Route
+     */
+    protected function generateRouteHierarchy()
+    {
+        $route1 = new Route();
+        $route1->setId('/route/main');
+        $route11 = new Route();
+        $route11->setId('/route/main/1');
+        $route12 = new Route();
+        $route12->setId('/route/main/2');
+
+        $refl = new \ReflectionClass($route1);
+        $prop = $refl->getProperty('children');
+        $prop->setAccessible(true);
+        $prop->setValue($route1, array(
+            $route11,
+            $route12,
+        ));
+
+        return $route1;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Here is an implementation : https://github.com/prestaconcept/PrestaCMSCoreBundle/blob/route-collection-hierarchy/Model/RouteManager.php#L36

My goal is to provide a sitemap.xml. I think it could be great to add this to the cmf route API.
