### PR TITLE
Fixed docblock comment to include whole ObjectManager path

### DIFF
--- a/Document/RouteProvider.php
+++ b/Document/RouteProvider.php
@@ -167,7 +167,7 @@ class RouteProvider implements RouteProviderInterface
     /**
      * Get the object manager from the registry, based on the current managerName
      *
-     * @return ObjectManager
+     * @return \Doctrine\Common\Persistence\ObjectManager
      */
     protected function getObjectManager()
     {


### PR DESCRIPTION
Just a tiny fix for the benefit of PHPStorm users. ;)
