### PR TITLE
Updated README to new, standard format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Symfony CMF Routing Bundle
 
-[![Build Status](https://secure.travis-ci.org/symfony-cmf/RoutingBundle.png)](http://travis-ci.org/symfony-cmf/RoutingBundle) [![Latest Stable Version](https://poser.pugx.org/symfony-cmf/routing-bundle/version.png)](https://packagist.org/packages/symfony-cmf/routing-bundle) [![Total Downloads](https://poser.pugx.org/symfony-cmf/routing-bundle/d/total.png)](https://packagist.org/packages/symfony-cmf/routing-bundle)
+[![Build Status](https://secure.travis-ci.org/symfony-cmf/RoutingBundle.png)](http://travis-ci.org/symfony-cmf/RoutingBundle)
+[![Latest Stable Version](https://poser.pugx.org/symfony-cmf/routing-bundle/version.png)](https://packagist.org/packages/symfony-cmf/routing-bundle)
+[![Total Downloads](https://poser.pugx.org/symfony-cmf/routing-bundle/d/total.png)](https://packagist.org/packages/symfony-cmf/routing-bundle)
 
 This bundle is part of the [Symfony Content Management Framework (CMF)](http://cmf.symfony.com/)
 and licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
See the [README proposal](https://github.com/symfony-cmf/symfony-cmf/wiki/README-format-proposal)

Note, I've cut most of the description, but it can go back in (and maybe rewritten to keep it a bit shorter) if needed.
