### PR TITLE
creating a sonata phpcr admin extension for linked routes

### DIFF
--- a/Admin/Extension/RouteReferrersExtension.php
+++ b/Admin/Extension/RouteReferrersExtension.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\RoutingBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminExtension;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+
+/**
+ * Admin extension to add routes tab to content implementing the
+ * RouteReferrersWriteInterface.
+ *
+ * @author David Buchmann <mail@davidbu.ch>
+ */
+class RouteReferrersExtension extends AdminExtension
+{
+    public function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_routes', array(
+                'translation_domain' => 'CmfRoutingBundle',
+            ))
+            ->add(
+                'routes',
+                'sonata_type_collection',
+                array(
+                    'by_reference' => false,
+                ),
+                array(
+                    'edit' => 'inline',
+                    'inline' => 'table',
+                ))
+            ->end()
+        ;
+    }
+}

--- a/Resources/config/admin_phpcr.xml
+++ b/Resources/config/admin_phpcr.xml
@@ -9,6 +9,7 @@
         <parameter key="cmf_routing.redirect_route_admin_class">Symfony\Cmf\Bundle\RoutingBundle\Admin\RedirectRouteAdmin</parameter>
         <parameter key="cmf_routing.route_document_class">Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route</parameter>
         <parameter key="cmf_routing.redirect_route_document_class">Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute</parameter>
+        <parameter key="cmf_routing.admin_extension.route_referrers.class">Symfony\Cmf\Bundle\RoutingBundle\Admin\Extension\RouteReferrersExtension</parameter>
     </parameters>
 
     <services>
@@ -48,6 +49,10 @@
             <call method="setRouteRoot">
                 <argument>%cmf_routing.persistence.phpcr.route_basepath%</argument>
             </call>
+        </service>
+
+        <service id="cmf_routing.admin_extension.route_referrers" class="%cmf_routing.admin_extension.route_referrers.class%">
+            <tag name="sonata.admin.extension"/>
         </service>
 
     </services>

--- a/Resources/translations/CmfRoutingBundle.de.yml
+++ b/Resources/translations/CmfRoutingBundle.de.yml
@@ -29,3 +29,5 @@ form:
     label_route_name: Name
     label_uri: URI
     label_route_target: Routenziel
+    group_routes: Routen
+    label_routes: Routen

--- a/Resources/translations/CmfRoutingBundle.en.yml
+++ b/Resources/translations/CmfRoutingBundle.en.yml
@@ -29,3 +29,5 @@ form:
     label_route_name: Name
     label_uri: URI
     label_route_target: Route target
+    group_routes: Routes
+    label_routes: Routes

--- a/Resources/translations/CmfRoutingBundle.fr.yml
+++ b/Resources/translations/CmfRoutingBundle.fr.yml
@@ -29,3 +29,5 @@ form:
     label_route_name: Nom
     label_uri: URI
     label_route_target: Route objectif
+    group_routes: Routes
+    label_routes: Routes

--- a/Resources/translations/CmfRoutingBundle.pl.yml
+++ b/Resources/translations/CmfRoutingBundle.pl.yml
@@ -30,3 +30,5 @@ form:
     label_route_name: Nazwa
     label_uri: URI
     label_route_target: Ścieżka wkazuje na
+    group_routes: Ścieżki
+    label_routes: Ścieżki

--- a/Tests/Functional/Doctrine/Phpcr/RedirectRouteTest.php
+++ b/Tests/Functional/Doctrine/Phpcr/RedirectRouteTest.php
@@ -52,7 +52,7 @@ class RedirectRouteTest extends BaseTestCase
      */
     public function testSetContent()
     {
-        $content = $this->getMock('Symfony\\Cmf\\Component\\Routing\\RouteAwareInterface');
+        $content = $this->getMock('Symfony\\Cmf\\Component\\Routing\\RouteReferrersInterface');
         $redirect = new RedirectRoute;
         $redirect->setContent($content);
     }


### PR DESCRIPTION
adding the admin extension for routes, similar to https://github.com/symfony-cmf/MenuBundle/pull/109 , last step to allow to solve https://github.com/symfony-cmf/ContentBundle/issues/39

this depends on https://github.com/symfony-cmf/Routing/pull/73
