### PR TITLE
support event handling for dynamic router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* **2013-07-31**: [EventDispatcher] Added events to the dynamic router at the start of match and matchRequest
 * **2013-07-29**: [DependencyInjection] restructured `phpcr_provider` config into `persistence` -> `phpcr` to match other Bundles
 * **2013-07-28**: [DependencyInjection] added `enabled` flag to `phpcr_provider` config
 * **2013-07-26**: [Model] Removed setRouteContent and getRouteContent, use setContent and getContent instead.

--- a/Resources/config/routing-dynamic.xml
+++ b/Resources/config/routing-dynamic.xml
@@ -54,8 +54,8 @@
             <argument type="service" id="router.request_context"/>
             <argument type="service" id="cmf_routing.nested_matcher" />
             <argument type="service" id="cmf_routing.generator" />
-            <argument type="service" id="event_dispatcher" />
             <argument>%cmf_routing.uri_filter_regexp%</argument>
+            <argument type="service" id="event_dispatcher" on-invalid="ignore"/>
             <call method="setContainer"><argument type="service" id="service_container"/></call>
             <call method="addRouteEnhancer"><argument type="service" id="cmf_routing.enhancer_route_content"/></call>
         </service>

--- a/Tests/Unit/Routing/ContentAwareGeneratorTest.php
+++ b/Tests/Unit/Routing/ContentAwareGeneratorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Routing;
+namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Unit\Routing;
 
 use Symfony\Component\HttpFoundation\Request;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #131, #119 |
| License | MIT |
| Doc PR | TODO @trsteel88 promised for later this week |

this depends on https://github.com/symfony-cmf/Routing/pull/76
