### PR TITLE
fix: uses doctrine mapping compiler when CoreBundle is not installed

### DIFF
--- a/CmfRoutingBundle.php
+++ b/CmfRoutingBundle.php
@@ -65,7 +65,7 @@ class CmfRoutingBundle extends Bundle
     {
         $symfonyVersion = class_exists('Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterMappingsPass');
 
-        if (symfonyVersion && class_exists('Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass')) {
+        if ($symfonyVersion && class_exists('Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass')) {
             return 'Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass';
         }
 


### PR DESCRIPTION
Fallback doctrine orm mapping in case CoreBundle is not installed
