### PR TITLE
fix locale handling in routing

### DIFF
--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -83,13 +83,18 @@ class CmfRoutingExtension extends Extension
         }
         $container->setParameter($this->getAlias() . '.defined_templates_class', $controllerForTemplates);
         $container->setParameter($this->getAlias() . '.uri_filter_regexp', $config['uri_filter_regexp']);
+        $locales = false;
+        if (isset($config['locales'])) {
+            $locales = $config['locales'];
+            $container->setParameter($this->getAlias() . '.dynamic.locales', $locales);
+        }
 
         $loader->load('routing-dynamic.xml');
 
         $hasProvider = false;
         $hasContentRepository = false;
         if (!empty($config['persistence']['phpcr']['enabled'])) {
-            $this->loadPhpcrProvider($config['persistence']['phpcr'], $loader, $container);
+            $this->loadPhpcrProvider($config['persistence']['phpcr'], $loader, $container, $locales);
             $hasProvider = true;
             $hasContentRepository = true;
         }
@@ -142,7 +147,7 @@ class CmfRoutingExtension extends Extension
         }
     }
 
-    public function loadPhpcrProvider($config, XmlFileLoader $loader, ContainerBuilder $container)
+    public function loadPhpcrProvider($config, XmlFileLoader $loader, ContainerBuilder $container, $locales)
     {
         $loader->load('provider-phpcr.xml');
 
@@ -156,9 +161,7 @@ class CmfRoutingExtension extends Extension
         $container->setAlias($this->getAlias() . '.route_provider', $this->getAlias() . '.phpcr_route_provider');
         $container->setAlias($this->getAlias() . '.content_repository', $this->getAlias() . '.phpcr_content_repository');
 
-        if (isset($config['locales']) && $config['locales']) {
-            $container->setParameter($this->getAlias() . '.locales', $config['locales']);
-        } else {
+        if (!$locales) {
             $container->removeDefinition('cmf_routing.phpcrodm_route_locale_listener');
         }
 

--- a/Resources/config/provider-phpcr.xml
+++ b/Resources/config/provider-phpcr.xml
@@ -32,7 +32,7 @@
 
         <service id="cmf_routing.phpcrodm_route_locale_listener" class="%cmf_routing.phpcrodm_route_locale_listener_class%">
             <argument>%cmf_routing.dynamic.persistence.phpcr.route_basepath%</argument>
-            <argument>%cmf_routing.locales%</argument>
+            <argument>%cmf_routing.dynamic.locales%</argument>
             <tag name="doctrine_phpcr.event_listener" event="postLoad" />
             <tag name="doctrine_phpcr.event_listener" event="postPersist" />
             <tag name="doctrine_phpcr.event_listener" event="postMove" />

--- a/Tests/Resources/app/config/cmf_routing.yml
+++ b/Tests/Resources/app/config/cmf_routing.yml
@@ -15,3 +15,6 @@ cmf_routing:
             phpcr:
                 enabled: true
                 route_basepath: /test/routing
+        locales:
+            - en
+            - de


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [- |
| License | MIT |
| Doc PR | - |

the locale listener was always removed, leading to routing being very confused and i.e. lunetics locale bundle always looking at browser or cookie and not at url.
