### PR TITLE
[WIP] Add route tree per hostname

### DIFF
--- a/Doctrine/Phpcr/Host.php
+++ b/Doctrine/Phpcr/Host.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr;
+
+class Host extends Route
+{
+}

--- a/Doctrine/Phpcr/IdPrefixListener.php
+++ b/Doctrine/Phpcr/IdPrefixListener.php
@@ -47,10 +47,20 @@ class IdPrefixListener
 
         // only update route objects and only if the prefix can match, to allow
         // for more than one listener and more than one route root
-        if (($doc instanceof PrefixInterface)
+        if (($doc instanceof Route)
             && ! strncmp($this->idPrefix, $doc->getId(), strlen($this->idPrefix))
         ) {
-            $doc->setPrefix($this->idPrefix);
+            $prefix = $this->idPrefix;
+            $parent = $doc;
+
+            do {
+                if ($parent instanceof Host) {
+                    $prefix = $parent->getId();
+                    break;
+                }
+            } while ($parent = $parent->getParent());
+
+            $doc->setPrefix($prefix);
         }
     }
 }

--- a/Resources/config/doctrine-phpcr/Host.phpcr.xml
+++ b/Resources/config/doctrine-phpcr/Host.phpcr.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping
+    xmlns="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping
+        https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd"
+>
+
+    <document name="Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Host" referenceable="true">
+    </document>
+
+</doctrine-mapping>


### PR DESCRIPTION
Hi !

Related to #33, I'm trying to find a solution to organize routes tree per hostname. The following code works, but I'm not sure that the good way to achieve this.

I created a new `Host` document which extends `Route`, this way it can behave like a `Route`, and is easy to identify. But I don't like having an empty objet, maybe you'll have a better idea.
- In the IdPrefixListener, I try to find a `Host` object and if one is found, I append it to the idPrefix
  `/cms/routes` will become `/cms/routes/<hostname>`
- Then in the `RouteProvider`, I keep the previous url candidates and I add new ones prefixed by the current request host : 

```
/cms/routes/test.html
/cms/routes/test
/cms/routes
```

and

```
/cms/routes/<hostname>/test.html
/cms/routes/<hostname>/test
/cms/routes/<hostname>
```

Feedback would be appreciated ! Thanks.
