### PR TITLE
Improved whitespace handling by Extension

### DIFF
--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -40,7 +40,7 @@ class CmfRoutingExtension extends Extension
         // add the routers defined in the configuration mapping
         $router = $container->getDefinition($this->getAlias() . '.router');
         foreach ($config['chain']['routers_by_id'] as $id => $priority) {
-            $router->addMethodCall('add', array(new Reference($id), $priority));
+            $router->addMethodCall('add', array(new Reference($id), trim($priority)));
         }
 
         $this->setupFormTypes($config, $container, $loader);
@@ -68,6 +68,13 @@ class CmfRoutingExtension extends Extension
      */
     private function setupDynamicRouter(array $config, ContainerBuilder $container, LoaderInterface $loader)
     {
+        // strip whitespace (XML support)
+        foreach (array('controllers_by_type', 'controllers_by_class', 'templates_by_class', 'route_filters_by_id') as $option) {
+            $config[$option] = array_map(function ($value) {
+                return trim($value);
+            }, $config[$option]);
+        }
+
         $container->setParameter($this->getAlias() . '.generic_controller', $config['generic_controller']);
         $container->setParameter($this->getAlias() . '.controllers_by_type', $config['controllers_by_type']);
         $container->setParameter($this->getAlias() . '.controllers_by_class', $config['controllers_by_class']);


### PR DESCRIPTION
When using XML, you often do something like:

``` rst
<controller-by-type type="Acme\Foo">
    200
</controller-by-type>
```

This will result in an error, because the value is not trimmed and the
priority contains a lot of whitespace.

In some cases, you don't want to trim the whitespace (for instance for
parameter values), but in this case I think it's save to trim them.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
