### PR TITLE
porting some help texts from simple cms to the routing

### DIFF
--- a/Admin/RouteAdmin.php
+++ b/Admin/RouteAdmin.php
@@ -75,9 +75,9 @@ class RouteAdmin extends Admin
                 array('choice_list' => array(), 'select_root_node' => true, 'root_node' => $this->routeRoot)
             )
             ->add('name', 'text')
-            ->add('addFormatPattern', null, array('required' => false))
-            ->add('addTrailingSlash', null, array('required' => false))
-            ->end();
+            ->add('addFormatPattern', null, array('required' => false, 'help' => 'form.help_add_format_pattern'))
+            ->add('addTrailingSlash', null, array('required' => false, 'help' => 'form.help_add_trailing_slash'))
+        ->end();
 
         if (null === $this->getParentFieldDescription()) {
             $formMapper
@@ -85,7 +85,7 @@ class RouteAdmin extends Admin
                 ->add('variablePattern', 'text', array('required' => false))
                 ->add('content', 'doctrine_phpcr_odm_tree', array('choice_list' => array(), 'required' => false, 'root_node' => $this->contentRoot))
                 ->add('defaults', 'sonata_type_immutable_array', array('keys' => $this->configureFieldsForDefaults()))
-                ->end();
+            ->end();
         }
     }
 

--- a/Resources/translations/CmfRoutingBundle.de.xliff
+++ b/Resources/translations/CmfRoutingBundle.de.xliff
@@ -106,6 +106,14 @@
         <source>form.label_add_trailing_slash</source>
         <target>Abschließenden Schrägstrich hinzufügen</target>
       </trans-unit>
+      <trans-unit id="form.help_add_format_pattern">
+        <source>form.help_add_format_pattern</source>
+        <target>Format zu URL hinzufügen: /eine/url.{format}. Wenn nichts angegeben wird ist das Format html.</target>
+      </trans-unit>
+      <trans-unit id="form.help_add_trailing_slash">
+        <source>form.help_add_trailing_slash</source>
+        <target>Die URL hört in diesem Fall mit einem Schrägstrich auf, zum Beispiel /eine/url/.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/CmfRoutingBundle.en.xliff
+++ b/Resources/translations/CmfRoutingBundle.en.xliff
@@ -106,6 +106,14 @@
         <source>form.label_add_trailing_slash</source>
         <target>Add trailing slash</target>
       </trans-unit>
+      <trans-unit id="form.help_add_format_pattern">
+        <source>form.help_add_format_pattern</source>
+        <target>Append format to route like /your/route.{format}. Default format is html.</target>
+      </trans-unit>
+      <trans-unit id="form.help_add_trailing_slash">
+        <source>form.help_add_trailing_slash</source>
+        <target>Append a trailing slash to route like /your/route/.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/CmfRoutingBundle.fr.xliff
+++ b/Resources/translations/CmfRoutingBundle.fr.xliff
@@ -106,6 +106,14 @@
         <source>form.label_add_trailing_slash</source>
         <target>Ajouter une barre oblique en fin</target>
       </trans-unit>
+      <trans-unit id="form.help_add_format_pattern">
+        <source>form.help_add_format_pattern</source>
+        <target>Ajoute le format à la route tel que /your/route.{format}. Le format par défaut est html.</target>
+      </trans-unit>
+      <trans-unit id="form.help_add_trailing_slash">
+        <source>form.help_add_trailing_slash</source>
+        <target>Ajoute un slash à la fin de la route tel que /your/route/.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

this help text was originally in SimpleCmsBundle but would be just as useful here. maybe we can change the admin of SimpleCmsBundle after merging this to translate those fields in the CmfRoutingBundle translation domain to avoid duplicating such help texts.
