### PR TITLE
follow the property access model with children

### DIFF
--- a/Doctrine/Phpcr/Route.php
+++ b/Doctrine/Phpcr/Route.php
@@ -246,12 +246,11 @@ class Route extends RouteModel implements PrefixInterface
     }
 
     /**
-     * Return this routes children
+     * Get all route children of this route.
      *
-     * Filters out children that do not implement
-     * the RouteObjectInterface.
+     * Filters out children that do not implement the RouteObjectInterface.
      *
-     * @return array - array of RouteObjectInterface's
+     * @return RouteObjectInterface[]
      *
      */
     public function getRouteChildren()
@@ -265,5 +264,15 @@ class Route extends RouteModel implements PrefixInterface
         }
 
         return $children;
+    }
+
+    /**
+     * Get all children of this route including non-routes.
+     *
+     * @return array
+     */
+    public function getChildren()
+    {
+        return $this->children;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (well, workaround for sonata admin shortcomings) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

with this change, routes will appear again in the sonata phpcr-odm as this follows the property access model of having getChildren to get the children property.
