### PR TITLE
Separate default controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,28 @@
 Changelog
 =========
 
+1.1.0
+-----
+
+* **2013-10-14**: The route enhancers now have a non-default priority so that
+  the order is defined and you can add your own enhancers.
+
 1.1.0-RC8
 ---------
 
-* **2013-10-08**: The idPrefix is now used as a filter in getRouteByName() and getRoutesByNames()
-  in the PHPCR RouteProvider. This means its no longer possible to get routes that are not children
-  of a path that begins with idPrefix
+* **2013-10-08**: The idPrefix is now used as a filter in getRouteByName() and
+  getRoutesByNames() in the PHPCR RouteProvider. This means its no longer
+  possible to get routes that are not children of a path that begins with
+  idPrefix.
 
 1.1.0-RC5
 ---------
 
-* **2013-09-04**: If the route matched a pattern with a format extension, the format
-  extension is no longer set as route a default
-* **2013-09-04**: Marked ContentAwareGenerator as obsolete, use ContentAwareGenerator
-   from the CMF routing component directly instead. This class will be removed in 1.2
+* **2013-09-04**: If the route matched a pattern with a format extension, the
+  format extension is no longer set as route a default.
+* **2013-09-04**: Marked ContentAwareGenerator as obsolete, use
+  ContentAwareGenerator from the CMF routing component directly instead. This
+  class will be removed in 1.2.
 * **2013-08-09**: dynamic.generic_controller is now defaulting to null instead
   of the controller from CmfContentBundle. CmfCoreBundle is prepending the
   CmfContentBundle generic controller if that bundle is present. If you do not
@@ -34,19 +42,29 @@ Changelog
 1.1.0-RC1
 ---------
 
-* **2013-07-31**: [EventDispatcher] Added events to the dynamic router at the start of match and matchRequest
-* **2013-07-29**: [DependencyInjection] restructured `phpcr_provider` config into `persistence` -> `phpcr` to match other Bundles
-* **2013-07-28**: [DependencyInjection] added `enabled` flag to `phpcr_provider` config
-* **2013-07-26**: [Model] Removed setRouteContent and getRouteContent, use setContent and getContent instead.
+* **2013-07-31**: [EventDispatcher] Added events to the dynamic router at the
+  start of match and matchRequest.
+* **2013-07-29**: [DependencyInjection] restructured `phpcr_provider` config
+  into `persistence` -> `phpcr` to match other Bundles.
+* **2013-07-28**: [DependencyInjection] added `enabled` flag to
+  `phpcr_provider` config.
+* **2013-07-26**: [Model] Removed setRouteContent and getRouteContent, use
+  setContent and getContent instead.
 * **2013-07-19**: [Model] Separated database agnostic, doctrine generic and
   PHPCR-ODM specific code to prepare for Doctrine ORM support.
-* **2013-07-17**: [FormType] Moved TermsFormType to CoreBundle and renamed it to CheckboxUrlLableFormType
+* **2013-07-17**: [FormType] Moved TermsFormType to CoreBundle and renamed it
+  to CheckboxUrlLableFormType.
 
 1.1.0-beta2
 -----------
 
-* **2013-05-28**: [Bundle] Only include Doctrine PHPCR compiler pass if PHPCR-ODM is present
-* **2013-05-25**: [Bundle] Drop symfony_ from symfony_cmf prefix
-* **2013-05-24**: [Document] ContentRepository now requires ManagerRegistry in the constructor and provides `setManagerName()` in the same way as RouteProvider
-* **2013-05-24**: [Document] RouteProvider now requires ManagerRegistry in the constructor (the `cmf_routing.default_route_provider` does this for you)
-  * To use a different document manager from the registry, call `setManagerName()` on the RouteProvider
+* **2013-05-28**: [Bundle] Only include Doctrine PHPCR compiler pass if
+  PHPCR-ODM is present.
+* **2013-05-25**: [Bundle] Drop symfony_ from symfony_cmf prefix.
+* **2013-05-24**: [Document] ContentRepository now requires ManagerRegistry in
+  the constructor and provides `setManagerName()` in the same way as
+  RouteProvider.
+* **2013-05-24**: [Document] RouteProvider now requires ManagerRegistry in the
+  constructor (the `cmf_routing.default_route_provider` does this for you). To
+  use a different document manager from the registry, call `setManagerName()`
+  on the RouteProvider.

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,6 +57,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeEnabled()
                     ->children()
                         ->scalarNode('generic_controller')->defaultNull()->end()
+                        ->scalarNode('default_controller')->defaultNull()->end()
                         ->arrayNode('controllers_by_type')
                             ->useAttributeAsKey('type')
                             ->prototype('scalar')->end()

--- a/Resources/config/routing-dynamic.xml
+++ b/Resources/config/routing-dynamic.xml
@@ -12,7 +12,8 @@
         <parameter key="cmf_routing.url_matcher.class">Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher</parameter>
         <parameter key="cmf_routing.generator.class">Symfony\Cmf\Component\Routing\ContentAwareGenerator</parameter>
         <parameter key="cmf_routing.enhancer.route_content.class">Symfony\Cmf\Component\Routing\Enhancer\RouteContentEnhancer</parameter>
-        <parameter key="cmf_routing.enhancer.generic_controller.class">Symfony\Cmf\Component\Routing\Enhancer\FieldPresenceEnhancer</parameter>
+        <parameter key="cmf_routing.enhancer.default_controller.class">Symfony\Cmf\Component\Routing\Enhancer\FieldPresenceEnhancer</parameter>
+        <parameter key="cmf_routing.enhancer.explicit_template.class">Symfony\Cmf\Component\Routing\Enhancer\FieldPresenceEnhancer</parameter>
         <parameter key="cmf_routing.enhancer.controllers_by_type.class">Symfony\Cmf\Component\Routing\Enhancer\FieldMapEnhancer</parameter>
         <parameter key="cmf_routing.enhancer.field_by_class.class">Symfony\Cmf\Component\Routing\Enhancer\FieldByClassEnhancer</parameter>
         <parameter key="cmf_routing.redirect_controller.class">Symfony\Cmf\Bundle\RoutingBundle\Controller\RedirectController</parameter>
@@ -24,8 +25,14 @@
             <argument>_content</argument>
         </service>
 
-        <service id="cmf_routing.enhancer.generic_controller" class="%cmf_routing.enhancer.generic_controller.class%" public="false">
+        <service id="cmf_routing.enhancer.default_controller" class="%cmf_routing.enhancer.default_controller.class%" public="false">
             <argument>null</argument>
+            <argument>_controller</argument>
+            <argument>%cmf_routing.default_controller%</argument>
+        </service>
+
+        <service id="cmf_routing.enhancer.explicit_template" class="%cmf_routing.enhancer.explicit_template.class%" public="false">
+            <argument>_template</argument>
             <argument>_controller</argument>
             <argument>%cmf_routing.generic_controller%</argument>
         </service>
@@ -61,7 +68,10 @@
             <argument>%cmf_routing.uri_filter_regexp%</argument>
             <argument type="service" id="event_dispatcher" on-invalid="ignore"/>
             <call method="setContainer"><argument type="service" id="service_container"/></call>
-            <call method="addRouteEnhancer"><argument type="service" id="cmf_routing.enhancer.route_content"/></call>
+            <call method="addRouteEnhancer">
+                <argument type="service" id="cmf_routing.enhancer.route_content"/>
+                <argument>100</argument>
+            </call>
         </service>
 
         <service id="cmf_routing.nested_matcher" class="%cmf_routing.nested_matcher.class%">

--- a/Tests/Functional/Routing/DynamicRouterTest.php
+++ b/Tests/Functional/Routing/DynamicRouterTest.php
@@ -217,6 +217,7 @@ class DynamicRouterTest extends BaseTestCase
         $this->getDm()->persist($route);
         $childroute = new Route;
         $childroute->setPosition($route, 'testroute');
+        $childroute->setDefault(RouteObjectInterface::CONTROLLER_NAME, 'testController');
         $this->getDm()->persist($childroute);
         $nolocale = new Route;
         $nolocale->setPosition($this->getDm()->find(null, self::ROUTE_ROOT), 'es');
@@ -234,6 +235,7 @@ class DynamicRouterTest extends BaseTestCase
             $this->router->match('/de')
         );
         $expected = array(
+            '_controller' => 'testController',
             '_locale' => 'de',
             '_route' => self::ROUTE_ROOT . '/de/testroute'
         );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | **no** |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/pull/304 |

alternative to #191 without a BC break and a tad more flexibility for edge cases (at the cost of a bit more complexity). by default, everything will work the same as with #191 but for example the SimpleCmsBundle does not fail with this PR whereas #191 would require adjustments there.
