### PR TITLE
admin show url in list instead of id

### DIFF
--- a/Admin/RouteAdmin.php
+++ b/Admin/RouteAdmin.php
@@ -52,7 +52,7 @@ class RouteAdmin extends Admin
     protected function configureListFields(ListMapper $listMapper)
     {
         $listMapper
-            ->addIdentifier('id', 'text')
+            ->addIdentifier('path', 'text')
         ;
     }
 

--- a/Resources/translations/CmfRoutingBundle.de.xliff
+++ b/Resources/translations/CmfRoutingBundle.de.xliff
@@ -50,9 +50,9 @@
         <source>filter.label_name</source>
         <target>Name</target>
       </trans-unit>
-      <trans-unit id="list.label_id">
-        <source>list.label_id</source>
-        <target>Id</target>
+      <trans-unit id="list.label_path">
+        <source>list.label_path</source>
+        <target>URL</target>
       </trans-unit>
       <trans-unit id="form.group_general">
         <source>form.group_general</source>

--- a/Resources/translations/CmfRoutingBundle.en.xliff
+++ b/Resources/translations/CmfRoutingBundle.en.xliff
@@ -50,9 +50,9 @@
         <source>filter.label_name</source>
         <target>Name</target>
       </trans-unit>
-      <trans-unit id="list.label_id">
-        <source>list.label_id</source>
-        <target>Id</target>
+      <trans-unit id="list.label_path">
+        <source>list.label_path</source>
+        <target>URL</target>
       </trans-unit>
       <trans-unit id="form.group_general">
         <source>form.group_general</source>

--- a/Resources/translations/CmfRoutingBundle.fr.xliff
+++ b/Resources/translations/CmfRoutingBundle.fr.xliff
@@ -50,9 +50,9 @@
         <source>filter.label_name</source>
         <target>Nom</target>
       </trans-unit>
-      <trans-unit id="list.label_id">
-        <source>list.label_id</source>
-        <target>Id</target>
+      <trans-unit id="list.label_path">
+        <source>list.label_path</source>
+        <target>URL</target>
       </trans-unit>
       <trans-unit id="form.group_general">
         <source>form.group_general</source>

--- a/Resources/translations/CmfRoutingBundle.nl.xliff
+++ b/Resources/translations/CmfRoutingBundle.nl.xliff
@@ -50,9 +50,9 @@
         <source>filter.label_name</source>
         <target>Naam</target>
       </trans-unit>
-      <trans-unit id="list.label_id">
-        <source>list.label_id</source>
-        <target>Id</target>
+      <trans-unit id="list.label_path">
+        <source>list.label_path</source>
+        <target>URL</target>
       </trans-unit>
       <trans-unit id="form.group_general">
         <source>form.group_general</source>

--- a/Resources/translations/CmfRoutingBundle.pl.xliff
+++ b/Resources/translations/CmfRoutingBundle.pl.xliff
@@ -50,9 +50,9 @@
         <source>filter.label_name</source>
         <target>Nazwa</target>
       </trans-unit>
-      <trans-unit id="list.label_id">
-        <source>list.label_id</source>
-        <target>Ścieżka</target>
+      <trans-unit id="list.label_path">
+        <source>list.label_path</source>
+        <target>URL</target>
       </trans-unit>
       <trans-unit id="form.group_general">
         <source>form.group_general</source>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | ? (sonata BC break) |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

this is an outcome of a user experience review we did on a project: the list views should be more semantic. the "id" means nothing to the end user. the URL path is what he cares about.

a more discrupting idea was to rename route to URL **in the interface** (i would not want to change the code, only the sonata translation files). i did it on a project by overwriting the relevant translation strings, and it looks indeed a lot better from an end user (=web editor) point of view. he should know what a URL is - but route means nothing to him. if there is no objections, i would like to push that into the bundle.
