### PR TITLE
Add missing RedirectRoute::getChildren method

### DIFF
--- a/Doctrine/Phpcr/RedirectRoute.php
+++ b/Doctrine/Phpcr/RedirectRoute.php
@@ -248,4 +248,14 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface
 
         return $children;
     }
+
+    /**
+     * Get all children of this route including non-routes.
+     *
+     * @return array
+     */
+    public function getChildren()
+    {
+        return $this->children;
+    }
 }


### PR DESCRIPTION
If I add a `Route` in a `RedirectRoute` it works, but the tree won't show the children, because of the missing `getChildren()` method. This happens [here](https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/master/Tree/PhpcrOdmTree.php#L298) : an exception is thrown and the `$prop` variable is `null`.
