### PR TITLE
Check parameter type

### DIFF
--- a/Doctrine/Phpcr/Route.php
+++ b/Doctrine/Phpcr/Route.php
@@ -97,8 +97,9 @@ class Route extends RouteModel implements PrefixInterface
      */
     public function setParent($parent)
     {
-        if(!is_object($parent))
+        if (!is_object($parent)) {
             throw new InvalidArgumentException("Parent must be an object ".gettype ($parent)." given.");
+        }
 
         $this->parent = $parent;
 
@@ -142,8 +143,9 @@ class Route extends RouteModel implements PrefixInterface
      */
     public function setPosition($parent, $name)
     {
-        if(!is_object($parent))
+        if (!is_object($parent)) {
             throw new InvalidArgumentException("Parent must be an object ".gettype ($parent)." given.");
+        }
 
         $this->parent = $parent;
         $this->name = $name;


### PR DESCRIPTION
Since the setParent and setPosition arguments expect an object we should check that that is what being provided. Rationale - As a noob user of the CMF components I wasn't sure I was supposed to be passing the parent object or path. When passing the path I would get odd errors such as:

```
PHP Warning:  spl_object_hash() expects parameter 1 to be object, string given in vendor/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/UnitOfWork.php on line 942
PHP Warning:  get_class() expects parameter 1 to be object, string given in vendor/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/UnitOfWork.php on line 944
```

This change fails sooner and in a better way in my opinion.
