### PR TITLE
[WIP] fix bug with setting locales

### DIFF
--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -94,8 +94,11 @@ class CmfRoutingExtension extends Extension
         $container->setParameter($this->getAlias() . '.uri_filter_regexp', $config['uri_filter_regexp']);
         $container->setParameter($this->getAlias() . '.route_collection_limit', $config['route_collection_limit']);
 
-        $locales = !empty($config['locales']) ? $config['locales'] : array();
+        $locales = empty($config['locales']) ? array() : $config['locales'];
         $container->setParameter($this->getAlias() . '.dynamic.locales', $locales);
+        if (count($locales) === 0 && $config['auto_locale_pattern']) {
+            throw new InvalidConfigurationException('It makes no sense to activate auto_locale_pattern when no locales are configured.');
+        }
         $container->setParameter($this->getAlias() . '.dynamic.auto_locale_pattern', $config['auto_locale_pattern']);
 
         $container->setParameter($this->getAlias() . '.dynamic.limit_candidates', $config['limit_candidates']);


### PR DESCRIPTION
This fixes (or should do) a bug which appears when no locales are set, but `cmf_routing.dynamic.locales` is used all across the bundle.

Will add some tests for that use case later, when my env is ready on my notebook, just wanna see what travis says.
