### PR TITLE
[WIP] add webtests, first try frontend test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
   - composer self-update
   - echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer require symfony/symfony:${SYMFONY_VERSION} --prefer-source
+  - vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
 
 script: phpunit --coverage-text
 

--- a/Tests/Resources/DataFixtures/Phpcr/LoadFrontendRouteData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadFrontendRouteData.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Resources\DataFixtures\PHPCR;
+
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use PHPCR\Util\NodeHelper;
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route;
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute;
+use Doctrine\ODM\PHPCR\Document\Generic;
+
+class LoadFrontendRouteData implements FixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        NodeHelper::createPath($manager->getPhpcrSession(), '/test');
+        $root = $manager->find(null, '/test');
+        $parent = new Generic;
+        $parent->setParent($root);
+        $parent->setNodename('routing');
+        $manager->persist($parent);
+
+        //create two prefixes as new candidates
+        $candidateOne = new Generic;
+        $candidateOne->setParent($parent);
+        $candidateOne->setNodename('candidate-1');
+        $manager->persist($candidateOne);
+
+        $candidateTwo = new Generic;
+        $candidateTwo->setParent($parent);
+        $candidateTwo->setNodename('candidate-2');
+        $manager->persist($candidateTwo);
+
+        $route = new Route;
+        $route->setParentDocument($candidateOne);
+        $route->setName('route-in-candidate-1');
+        $route->setStaticPrefix('/test/routing/candidate-1');
+        $manager->persist($route);
+
+        $route = new Route;
+        $route->setParentDocument($candidateTwo);
+        $route->setStaticPrefix('/test/routing/candidate-2');
+        $route->setName('route-in-candidate-2');
+        $manager->persist($route);
+
+        $redirectRoute = new RedirectRoute;
+        $redirectRoute->setParentDocument($candidateOne);
+        $redirectRoute->setName('redirect-route-1');
+        $manager->persist($redirectRoute);
+
+        $manager->flush();
+    }
+}

--- a/Tests/Unit/Doctrine/Phpcr/RouteTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/RouteTest.php
@@ -48,4 +48,21 @@ class RouteTest extends \PHPUnit_Framework_Testcase
         $res = $this->route->getRouteChildren();
         $this->assertEquals(array(), $res);
     }
+
+    public function testRouteGetPathWithPrefix()
+    {
+        $route = new Route();
+        $route->setId('/cms/routes/my-route');
+        $route->setPrefix('/cms/routes');
+
+        $this->assertEquals('/my-route', $route->getPath());
+    }
+
+    public function testRouteGetPath()
+    {
+        $route = new Route();
+        $route->setId('/cms/routes/my-route');
+
+        $this->assertEquals('/my-route', $route->getPath());
+    }
 }

--- a/Tests/WebTest/FrontendWebTest.php
+++ b/Tests/WebTest/FrontendWebTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\WebTest;
+
+
+use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+
+class FrontendWebTest extends BaseTestCase
+{
+    public function setUp()
+    {
+        $this->db('PHPCR')->loadFixtures(array(
+            'Symfony\Cmf\Bundle\SeoBundle\Tests\Resources\DataFixtures\Phpcr\LoadContentData',
+        ));
+        $this->client = $this->createClient();
+    }
+
+    public function testCandidateRoutes()
+    {
+        $this->client->request('GET', '/route-in-candidate-1');
+        $res = $this->client->getResponse();
+
+        $this->assertEquals(200, $res->getStatusCode());
+
+        $this->client->request('GET', '/route-in-candidate-2');
+        $res = $this->client->getResponse();
+
+        $this->assertEquals(200, $res->getStatusCode());
+    }
+}
+ 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,11 @@
         <testsuite name="orm">
             <directory>./Tests/Functional/Doctrine/Orm</directory>
         </testsuite>
+
+        <testsuite name="WebTest">
+            <directory>./Tests/WebTest</directory>
+        </testsuite>
+
     </testsuites>
 
     <filter>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | https://github.com/symfony-cmf/RoutingBundle/issues/230, parts of https://github.com/symfony-cmf/symfony-cmf-docs/issues/444
| License       | MIT
| Doc PR        | need to be created

Please do not be confused, but i try to understand that Prefix/Candidates thing. To do that i (re-)activated the frontend test, do not know why they where not active. Then i created some routes, i just wanna play how `idPrefix`, `staticPrefix`and the candidates work together.

I got an issue with instantiating the database for the test - hope not to have it in travis.