### PR TITLE
reintroduce the old cmf_routing.dynamic.persistence.phpcr.route_basepath parameter to maintain BC

### DIFF
--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -239,6 +239,13 @@ class CmfRoutingExtension extends Extension
             $this->getAlias() . '.dynamic.persistence.phpcr.route_basepaths',
             $config['route_basepaths']
         );
+
+        $basePath = reset($config['route_basepaths']);
+        $container->setParameter(
+            $this->getAlias() . '.dynamic.persistence.phpcr.route_basepath',
+            $basePath
+        );
+
         $container->setParameter(
             $this->getAlias() . '.dynamic.persistence.phpcr.content_basepath',
             $config['content_basepath']


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #234 |
| License | MIT |
| Doc PR | - |
