### PR TITLE
no longer swallow the phpcr-odm exception

### DIFF
--- a/Resources/config/provider-phpcr.xml
+++ b/Resources/config/provider-phpcr.xml
@@ -17,6 +17,7 @@
             <argument type="service" id="doctrine_phpcr"/>
             <argument type="service" id="cmf_routing.phpcr_candidates_prefix"/>
             <argument>%cmf_routing.route_model.class%</argument>
+            <argument type="service" id="logger" on-invalid="ignore" />
             <call method="setManagerName"><argument>%cmf_routing.dynamic.persistence.phpcr.manager_name%</argument></call>
             <call method="setRouteCollectionLimit"><argument>%cmf_routing.route_collection_limit%</argument></call>
         </service>


### PR DESCRIPTION
as it only occurs when something really went wrong. the candidates strategy now checks to only try valid paths.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #143 |
| License | MIT |
| Doc PR | - |
