### PR TITLE
set the route_collection_limit to 0 by default for BC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 1.2.0-RC2
 ---------
 
+* **2014-04-23**: changed ``cmf_routing.dynamic.route_collection_limit`` default to ``0``
+
 * **2014-04-15**: Removed the unused ContentAwareGenerator class from the
   bundle. Since 1.1 the one from the routing component was used.
 
@@ -32,6 +34,9 @@ Changelog
 
 * **2014-03-23**: When using PHPCR-ODM, routes can now be generated with their
   uuid as route name as well, in addition to the repository path.
+
+* **2013-12-23**: add support for ChainRouter::getRouteCollection(), added new
+  config setting ``cmf_routing.dynamic.route_collection_limit``
 
 * **2013-11-28**: [BC BREAK for xml configuration] the alias attribute of the
   <template-by-class> is renamed to class in the bundle configuration.

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -56,7 +56,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->canBeEnabled()
                     ->children()
-                        ->scalarNode('route_collection_limit')->defaultNull()->end()
+                        ->scalarNode('route_collection_limit')->defaultValue(0)->end()
                         ->scalarNode('generic_controller')->defaultNull()->end()
                         ->scalarNode('default_controller')->defaultNull()->end()
                         ->arrayNode('controllers_by_type')

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -39,7 +39,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'replace_symfony_router' => true,
             ),
             'dynamic' => array(
-                'route_collection_limit' => null,
+                'route_collection_limit' => 0,
                 'generic_controller' => 'acme_main.controller:mainAction',
                 'controllers_by_type' => array(
                     'editable' => 'acme_main.some_controller:editableAction',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony-cmf/RoutingBundle/issues/241 |
| License | MIT |
| Doc PR | - |
