### PR TITLE
use phpcr-odm interface to avoid core bundle dependency

### DIFF
--- a/Doctrine/Phpcr/RedirectRoute.php
+++ b/Doctrine/Phpcr/RedirectRoute.php
@@ -12,9 +12,9 @@
 namespace Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr;
 
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\PHPCR\HierarchyInterface;
 use Symfony\Cmf\Bundle\RoutingBundle\Model\RedirectRoute as RedirectRouteModel;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
-use Symfony\Cmf\Bundle\CoreBundle\Model\ChildInterface;
 
 /**
  * {@inheritDoc}
@@ -22,7 +22,7 @@ use Symfony\Cmf\Bundle\CoreBundle\Model\ChildInterface;
  * This extends the RedirectRoute Model. We need to re-implement everything
  * that the PHPCR Route document adds.
  */
-class RedirectRoute extends RedirectRouteModel implements PrefixInterface, ChildInterface
+class RedirectRoute extends RedirectRouteModel implements PrefixInterface, HierarchyInterface
 {
     /**
      * parent document
@@ -92,6 +92,8 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Child
      * Note that this will change the URL this route matches.
      *
      * @param object $parent the new parent document
+     *
+     * @return $this
      */
     public function setParentDocument($parent)
     {
@@ -100,6 +102,9 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Child
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getParentDocument()
     {
         return $this->parent;

--- a/Doctrine/Phpcr/Route.php
+++ b/Doctrine/Phpcr/Route.php
@@ -13,9 +13,9 @@ namespace Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\PHPCR\HierarchyInterface;
 use Doctrine\ODM\PHPCR\Document\Generic;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
-use Symfony\Cmf\Bundle\CoreBundle\Model\ChildInterface;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Cmf\Bundle\RoutingBundle\Model\Route as RouteModel;
 
@@ -25,7 +25,7 @@ use Symfony\Cmf\Bundle\RoutingBundle\Model\Route as RouteModel;
  *
  * @author david.buchmann@liip.ch
  */
-class Route extends RouteModel implements PrefixInterface, ChildInterface
+class Route extends RouteModel implements PrefixInterface, HierarchyInterface
 {
     /**
      * parent document
@@ -128,7 +128,7 @@ class Route extends RouteModel implements PrefixInterface, ChildInterface
      * The parent document, which might be another route or some other
      * document.
      *
-     * @return Generic object
+     * @return object The parent document
      */
     public function getParentDocument()
     {


### PR DESCRIPTION
this should work, but only once https://github.com/symfony-cmf/CoreBundle/pull/138 is merged will sonata work as expected again.

fix #246
