### PR TITLE
make initializer optional

### DIFF
--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -287,6 +287,10 @@ class CmfRoutingExtension extends Extension
         $container->setParameter($this->getAlias() . '.dynamic.persistence.phpcr.admin_basepath', $basePath);
 
         $loader->load('admin-phpcr.xml');
+
+        if ($config['enable_initializer']) {
+            $loader->load('initializer-phpcr.xml');
+        }
     }
 
     public function loadOrmProvider($config, XmlFileLoader $loader, ContainerBuilder $container, $matchImplicitLocale)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -108,6 +108,7 @@ class Configuration implements ConfigurationInterface
                                             ->values(array(true, false, 'auto'))
                                             ->defaultValue('auto')
                                         ->end()
+                                        ->booleanNode('enable_initializer')->defaultTrue()->end()
                                     ->end()
                                 ->end()
                                 ->arrayNode('orm')

--- a/Resources/config/admin-phpcr.xml
+++ b/Resources/config/admin-phpcr.xml
@@ -55,13 +55,5 @@
             <tag name="sonata.admin.extension"/>
         </service>
 
-        <service id="cmf_routing.initializer" class="Doctrine\Bundle\PHPCRBundle\Initializer\GenericInitializer">
-            <argument>CmfRoutingBundle</argument>
-            <argument type="collection">
-                <argument>%cmf_routing.dynamic.persistence.phpcr.admin_basepath%</argument>
-            </argument>
-            <tag name="doctrine_phpcr.initializer"/>
-        </service>
-
     </services>
 </container>

--- a/Resources/config/initializer-phpcr.xml
+++ b/Resources/config/initializer-phpcr.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="cmf_routing.initializer" class="Doctrine\Bundle\PHPCRBundle\Initializer\GenericInitializer">
+            <argument>CmfRoutingBundle</argument>
+            <argument type="collection">
+                <argument>%cmf_routing.dynamic.persistence.phpcr.admin_basepath%</argument>
+            </argument>
+            <tag name="doctrine_phpcr.initializer"/>
+        </service>
+
+    </services>
+</container>

--- a/Resources/config/schema/routing-1.0.xsd
+++ b/Resources/config/schema/routing-1.0.xsd
@@ -85,6 +85,7 @@
         <xsd:attribute name="route-basepath" type="xsd:string" />
         <xsd:attribute name="content-basepath" type="xsd:string" />
         <xsd:attribute name="use-sonata-admin" type="enable_auto" />
+        <xsd:attribute name="enable-initializer" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="route_basepath">

--- a/Tests/Resources/Fixtures/config/config.php
+++ b/Tests/Resources/Fixtures/config/config.php
@@ -27,6 +27,7 @@ $container->loadFromExtension('cmf_routing', array(
                 ),
                 'content_basepath' => '/cms/content',
                 'use_sonata_admin' => 'false',
+                'enable_initializer' => true,
             ),
         ),
         'locales' => array('en', 'fr'),

--- a/Tests/Resources/Fixtures/config/config.xml
+++ b/Tests/Resources/Fixtures/config/config.xml
@@ -26,6 +26,7 @@
                     route-basepath="/cms/routes"
                     content-basepath="/cms/content"
                     use-sonata-admin="false"
+                    enable-initializer="true"
                 >
                     <route-basepath>/simple</route-basepath>
                 </phpcr>

--- a/Tests/Resources/Fixtures/config/config.yml
+++ b/Tests/Resources/Fixtures/config/config.yml
@@ -19,6 +19,7 @@ cmf_routing:
                     - /simple
                 content_basepath: /cms/content
                 use_sonata_admin: false
+                enable_initializer: true
         locales: [en, fr]
         auto_locale_pattern: true
         match_implicit_locale: true

--- a/Tests/Resources/Fixtures/config/config3.xml
+++ b/Tests/Resources/Fixtures/config/config3.xml
@@ -6,6 +6,7 @@
                 route-basepath="/cms/routes"
                 content-basepath="/cms/content"
                 use-sonata-admin="auto"
+                enable-initializer="true"
             />
         </persistence>
     </dynamic>

--- a/Tests/Unit/DependencyInjection/CmfRoutingExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/CmfRoutingExtensionTest.php
@@ -165,4 +165,74 @@ class CmfRoutingExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('cmf_routing.dynamic.persistence.phpcr.admin_basepath', '/cms/routes');
         $this->assertContainerBuilderHasParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths', array('/cms/routes', '/cms/test'));
     }
+
+    public function testInitializerEnabled()
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            array(
+                'CmfRoutingBundle' => true,
+                'SonataDoctrinePHPCRAdminBundle' => true,
+            )
+        );
+
+        $this->load(array(
+            'dynamic' => array(
+                'enabled' => true,
+                'persistence' => array(
+                    'phpcr' => array(
+                        'enabled' => true,
+                        'use_sonata_admin' => true,
+                        'enable_initializer' => true,
+                    ),
+                ),
+            ),
+        ));
+
+        $this->assertContainerBuilderHasService('cmf_routing.initializer', 'Doctrine\Bundle\PHPCRBundle\Initializer\GenericInitializer');
+    }
+
+    public function testInitializerDisabled()
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            array(
+                'CmfRoutingBundle' => true,
+                'SonataDoctrinePHPCRAdminBundle' => true,
+            )
+        );
+
+        $this->load(array(
+            'dynamic' => array(
+                'enabled' => true,
+                'persistence' => array(
+                    'phpcr' => array(
+                        'enabled' => true,
+                        'use_sonata_admin' => true,
+                        'enable_initializer' => false,
+                    ),
+                ),
+            ),
+        ));
+
+        $this->assertFalse($this->container->has('cmf_routing.initializer'));
+    }
+
+    public function testInitializerDisabledWithoutSonata()
+    {
+        $this->load(array(
+                'dynamic' => array(
+                    'enabled' => true,
+                    'persistence' => array(
+                        'phpcr' => array(
+                            'enabled' => true,
+                            'use_sonata_admin' => false,
+                        ),
+                    ),
+                ),
+            ));
+
+        $this->assertFalse($this->container->has('cmf_routing.initializer'));
+    }
+
 }

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -59,6 +59,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                         'content_basepath' => '/cms/content',
                         'manager_name' => null,
                         'use_sonata_admin' => false,
+                        'enable_initializer' => true,
                     ),
                     'orm' => array(
                         'enabled' => false,


### PR DESCRIPTION
Add a config option to make the initializer optional.
Currently this option is only relevant if sonata admin is used (BC).

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony-cmf/RoutingBundle/issues/250 |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/issues/525 |
