### PR TITLE
provide namespace alias for documents

### DIFF
--- a/CmfRoutingBundle.php
+++ b/CmfRoutingBundle.php
@@ -63,7 +63,8 @@ class CmfRoutingBundle extends Bundle
                     realpath(__DIR__.'/Resources/config/doctrine-phpcr') => 'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr',
                 ),
                 array('cmf_routing.dynamic.persistence.phpcr.manager_name'),
-                'cmf_routing.backend_type_phpcr'
+                'cmf_routing.backend_type_phpcr',
+                array('CmfRoutingBundle' => 'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr')
             )
         );
     }
@@ -95,7 +96,8 @@ class CmfRoutingBundle extends Bundle
                     realpath(__DIR__ . '/Resources/config/doctrine-orm') => 'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm',
                 ),
                 array('cmf_routing.dynamic.persistence.orm.manager_name'),
-                'cmf_routing.backend_type_orm'
+                'cmf_routing.backend_type_orm',
+                array('CmfRoutingBundle' => 'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm')
             )
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | travis |
| Fixed tickets | https://github.com/symfony-cmf/symfony-cmf/issues/204 |
| License | MIT |
| Doc PR | Should we update the doc to use namespaces where possible? I guess only when symfony 2.6 is out and the sandbox running on 2.6 - https://github.com/symfony-cmf/symfony-cmf-docs/issues/534 |

This will only do something with symfony 2.6+ and phpcr-bundle 1.2+, but is just passing an ignored additional parameter on older versions. Still lets wait for https://github.com/doctrine/DoctrinePHPCRBundle/pull/158 before merging.
