### PR TITLE
[Fix] CSS classes for the SonataFrontendLinkExtension

### DIFF
--- a/Admin/Extension/FrontendLinkExtension.php
+++ b/Admin/Extension/FrontendLinkExtension.php
@@ -79,7 +79,13 @@ class FrontendLinkExtension extends AdminExtension
             $this->translator->trans('admin.menu_frontend_link_caption', array(), 'CmfRoutingBundle'),
             array(
                 'uri' => $uri,
+                'attributes' => array(
+                    'class' => 'sonata-admin-menu-item',
+                    'role' => 'menuitem'
+                ),
                 'linkAttributes' => array(
+                    'class' => 'sonata-admin-frontend-link',
+                    'role' => 'button',
                     'target' => '_blank',
                     'title' => $this->translator->trans('admin.menu_frontend_link_title', array(), 'CmfRoutingBundle')
                 )


### PR DESCRIPTION
Had to add specific CSS classes to identify the button for styling in symfony-cmf/cmf-sandbox#276.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
