### PR TITLE
Fixes error with unperisted dynamic route in sonata FrontendLinkExtension

### DIFF
--- a/Admin/Extension/FrontendLinkExtension.php
+++ b/Admin/Extension/FrontendLinkExtension.php
@@ -15,6 +15,7 @@ use Knp\Menu\ItemInterface as MenuItemInterface;
 use Sonata\AdminBundle\Admin\AdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\PrefixInterface;
 use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Routing\Exception\ExceptionInterface as RoutingExceptionInterface;
@@ -68,7 +69,7 @@ class FrontendLinkExtension extends AdminExtension
             );
         }
 
-        if ($subject instanceof PrefixInterface && !is_string($subject->getId())) { 
+        if ($subject instanceof PrefixInterface && !is_string($subject->getId())) {
             // we have an unpersisted dynamic route 
             return; 
         }


### PR DESCRIPTION
Fixes a serious error at the `\Symfony\Cmf\Bundle\RoutingBundle\Admin\Extension\FrontendLinkExtension` when a new dynamic route is created in sonata admin:

```
An exception has been thrown during the rendering of a template ("Can not determine the prefix. 
Either this is a new, unpersisted document or the listener that calls setPrefix is not set up correctly.") 
in SonataAdminBundle:CRUD:base_edit.html.twig at line 34.
```

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | symfony-cmf/cmf-sandbox#276 |
| License | MIT |
| Doc PR | none |
