### PR TITLE
Testing fixes and improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
   - composer self-update
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;' 
   - composer require symfony/symfony:${SYMFONY_VERSION} --prefer-source
+  - vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
 
 script: phpunit --coverage-text
 

--- a/Admin/Extension/FrontendLinkExtension.php
+++ b/Admin/Extension/FrontendLinkExtension.php
@@ -14,13 +14,13 @@ namespace Symfony\Cmf\Bundle\RoutingBundle\Admin\Extension;
 use Knp\Menu\ItemInterface as MenuItemInterface;
 use Sonata\AdminBundle\Admin\AdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\PrefixInterface;
 use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Routing\Exception\ExceptionInterface as RoutingExceptionInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Admin extension to add a frontend link to the edit tab implementing the
@@ -36,20 +36,24 @@ class FrontendLinkExtension extends AdminExtension
     private $router;
 
     /**
-     * @var Translator
+     * @var TranslatorInterface
      */
     private $translator;
 
     /**
      * @param RouterInterface $router
-     * @param Translator $translator
+     * @param TranslatorInterface $translator
      */
-    public function __construct(RouterInterface $router, Translator $translator)
+    public function __construct(RouterInterface $router, TranslatorInterface $translator)
     {
         $this->router = $router;
         $this->translator = $translator;
     }
 
+    /**
+     * @return void
+     * @throws InvalidConfigurationException
+     */
     public function configureTabMenu(
         AdminInterface $admin,
         MenuItemInterface $menu,
@@ -71,7 +75,7 @@ class FrontendLinkExtension extends AdminExtension
 
         if ($subject instanceof PrefixInterface && !is_string($subject->getId())) {
             // we have an unpersisted dynamic route 
-            return; 
+            return;
         }
 
         try {

--- a/Tests/Resources/app/config/config_phpcr.php
+++ b/Tests/Resources/app/config/config_phpcr.php
@@ -6,3 +6,4 @@ $loader->import(CMF_TEST_CONFIG_DIR.'/phpcr_odm.php');
 $loader->import(CMF_TEST_CONFIG_DIR.'/sonata_admin.php');
 $loader->import(__DIR__.'/cmf_routing.yml');
 $loader->import(__DIR__.'/cmf_routing.phpcr.yml');
+$loader->import(__DIR__.'/sonata_admin.yml');

--- a/Tests/Resources/app/config/sonata_admin.yml
+++ b/Tests/Resources/app/config/sonata_admin.yml
@@ -1,0 +1,7 @@
+sonata_admin:
+    extensions:
+        cmf_routing.admin_extension.frontend_link:
+            implements:
+                - Symfony\Cmf\Component\Routing\RouteReferrersReadInterface
+            extends:
+                - Symfony\Component\Routing\Route

--- a/Tests/WebTest/RouteAdminTest.php
+++ b/Tests/WebTest/RouteAdminTest.php
@@ -12,9 +12,15 @@
 namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\WebTest;
 
 use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 
 class RouteAdminTest extends BaseTestCase
 {
+    /**
+     * @var \Symfony\Bundle\FrameworkBundle\Client
+     */
+    private $client;
+
     public function setUp()
     {
         $this->db('PHPCR')->loadFixtures(array(
@@ -37,11 +43,15 @@ class RouteAdminTest extends BaseTestCase
         $res = $this->client->getResponse();
         $this->assertEquals(200, $res->getStatusCode());
         $this->assertCount(1, $crawler->filter('input[value="route-1"]'));
+
+        $this->assertFrontendLinkPresent($crawler);
     }
 
     public function testRouteShow()
     {
-        $this->markTestSkipped('Not implemented yet.');
+        $crawler = $this->client->request('GET', '/admin/cmf/routing/route/test/routing/route-1/show');
+        $res = $this->client->getResponse();
+        $this->assertEquals(200, $res->getStatusCode());
     }
 
     public function testRouteCreate()
@@ -50,19 +60,38 @@ class RouteAdminTest extends BaseTestCase
         $res = $this->client->getResponse();
         $this->assertEquals(200, $res->getStatusCode());
 
+        $this->assertFrontendLinkNotPresent($crawler);
+
         $button = $crawler->selectButton('Create');
         $form = $button->form();
         $node = $form->getFormNode();
         $actionUrl = $node->getAttribute('action');
         $uniqId = substr(strchr($actionUrl, '='), 1);
 
-        $form[$uniqId.'[parent]'] = '/test/routing';
-        $form[$uniqId.'[name]'] = 'foo-test';
+        $form[$uniqId . '[parent]'] = '/test/routing';
+        $form[$uniqId . '[name]'] = 'foo-test';
 
         $this->client->submit($form);
         $res = $this->client->getResponse();
 
         // If we have a 302 redirect, then all is well
         $this->assertEquals(302, $res->getStatusCode());
+    }
+
+    /**
+     * @param Crawler $crawler
+     */
+    private function assertFrontendLinkPresent(Crawler $crawler)
+    {
+        $this->assertCount(1, $link = $crawler->filter('a[class="sonata-admin-frontend-link"]'));
+        $this->assertEquals('/route-1', $link->attr('href'));
+    }
+
+    /**
+     * @param Crawler $crawler
+     */
+    private function assertFrontendLinkNotPresent(Crawler $crawler)
+    {
+        $this->assertCount(0, $crawler->filter('a[class="sonata-admin-frontend-link"]'));
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,10 @@
             <directory>./Tests/Unit</directory>
         </testsuite>
 
+        <testsuite name="web-test">
+            <directory>./Tests/WebTest</directory>
+        </testsuite>
+
         <testsuite name="phpcr">
             <directory>./Tests/Functional</directory>
             <exclude>./Tests/Functional/Doctrine/Orm</exclude>


### PR DESCRIPTION
**TODO**
- [x] Reactivates [WebTests](https://github.com/symfony-cmf/RoutingBundle/tree/master/Tests/WebTest)
- [x] Reactivates / implement skipped ones
- [x] Adds tests for the sonata extensions
- [x] Fixes FrontendLinkExtension compatibility with Symfony 2.6

Part of the discussion in #275... 

**PR-Doc**

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | maybe partially #232 |
| License | MIT |
| Doc PR |  |
