### PR TITLE
Use the tab features of SonataAdminBundle 2.3

### DIFF
--- a/Admin/Extension/RouteReferrersExtension.php
+++ b/Admin/Extension/RouteReferrersExtension.php
@@ -22,20 +22,43 @@ use Sonata\AdminBundle\Form\FormMapper;
  */
 class RouteReferrersExtension extends AdminExtension
 {
+    /**
+     * @var string
+     */
+    private $formGroup;
+
+    /**
+     * @var string
+     */
+    private $formTab;
+
+    public function __construct($formGroup = 'form.group_routes', $formTab = 'form.tab_routing')
+    {
+        $this->formGroup = $formGroup;
+        $this->formTab = $formTab;
+    }
+
     public function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
-            ->with('form.group_routes', array(
-                'translation_domain' => 'CmfRoutingBundle',
-            ))
-            ->add(
-                'routes',
-                'sonata_type_collection',
-                array(),
-                array(
-                    'edit' => 'inline',
-                    'inline' => 'table',
-                ))
+            ->with($this->formTab, 'form.tab_routing' === $this->formTab
+                ? array('translation_domain' => 'CmfRoutingBundle', 'tab' => true)
+                : array('tab' => true)
+            )
+                ->with($this->formGroup, 'form.group_routes' === $this->formGroup
+                    ? array('translation_domain' => 'CmfRoutingBundle')
+                    : array()
+                )
+                    ->add(
+                        'routes',
+                        'sonata_type_collection',
+                        array(),
+                        array(
+                            'edit' => 'inline',
+                            'inline' => 'table',
+                        )
+                    )
+                ->end()
             ->end()
         ;
     }

--- a/Admin/RouteAdmin.php
+++ b/Admin/RouteAdmin.php
@@ -58,42 +58,60 @@ class RouteAdmin extends Admin
     protected function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
-            ->with('form.group_general', array(
-                'translation_domain' => 'CmfRoutingBundle',
-            ))
-                ->add(
-                    'parent',
-                    'doctrine_phpcr_odm_tree',
-                    array('choice_list' => array(), 'select_root_node' => true, 'root_node' => $this->routeRoot)
-                )
-                ->add('name', 'text')
-        ->end();
+            ->tab('form.tab_general', array('translation_domain' => 'CmfRoutingBundle'))
+                ->with('form.group_location', array(
+                    'class' => 'col-md-3',
+                    'translation_domain' => 'CmfRoutingBundle'
+                ))
+                    ->add(
+                        'parent',
+                        'doctrine_phpcr_odm_tree',
+                        array('choice_list' => array(), 'select_root_node' => true, 'root_node' => $this->routeRoot)
+                    )
+                    ->add('name', 'text')
+                ->end(); // group location
 
         if (null === $this->getParentFieldDescription()) {
             $formMapper
-                ->with('form.group_general', array(
-                    'translation_domain' => 'CmfRoutingBundle',
-                ))
-                    ->add('content', 'doctrine_phpcr_odm_tree', array('choice_list' => array(), 'required' => false, 'root_node' => $this->contentRoot))
-                ->end()
-                ->with('form.group_advanced', array(
-                    'translation_domain' => 'CmfRoutingBundle',
-                ))
-                    ->add('variablePattern', 'text', array('required' => false), array('help' => 'form.help_variable_pattern'))
-                    ->add(
-                        'defaults',
-                        'sonata_type_immutable_array',
-                        array('keys' => $this->configureFieldsForDefaults($this->getSubject()->getDefaults()))
-                    )
-                    ->add(
-                        'options',
-                        'sonata_type_immutable_array',
-                        array(
-                            'keys' => $this->configureFieldsForOptions($this->getSubject()->getOptions())),
-                        array('help' => 'form.help_options')
-                    )
-                ->end()
-            ->end();
+                    ->with('form.group_general', array(
+                        'class' => 'col-md-9',
+                        'translation_domain' => 'CmfRoutingBundle'
+                    ))
+                        ->add('content', 'doctrine_phpcr_odm_tree', array('choice_list' => array(), 'required' => false, 'root_node' => $this->contentRoot))
+                    ->end() // group general
+                ->end() // tab general
+
+                ->tab('form.tab_routing', array('translation_domain' => 'CmfRoutingBundle'))
+                    ->with('form.group_path', array(
+                        'class' => 'col-md-6',
+                        'translation_domain' => 'CmfRoutingBundle'
+                    ))
+                        ->add(
+                            'variablePattern',
+                            'text',
+                            array('required' => false),
+                            array('help' => 'form.help_variable_pattern')
+                        )
+                        ->add(
+                            'options',
+                            'sonata_type_immutable_array',
+                            array('keys' => $this->configureFieldsForOptions($this->getSubject()->getOptions())),
+                            array('help' => 'form.help_options')
+                        )
+                    ->end() // group path
+
+                    ->with('form.group_data', array(
+                        'class' => 'col-md-6',
+                        'translation_domain' => 'CmfRoutingBundle'
+                    ))
+                        ->add(
+                            'defaults',
+                            'sonata_type_immutable_array',
+                            array('keys' => $this->configureFieldsForDefaults($this->getSubject()->getDefaults()))
+                        )
+                    ->end() // group data
+                ->end() // tab routing
+            ;
         }
     }
 

--- a/Resources/translations/CmfRoutingBundle.de.xliff
+++ b/Resources/translations/CmfRoutingBundle.de.xliff
@@ -54,8 +54,8 @@
         <source>list.label_path</source>
         <target>URL</target>
       </trans-unit>
-      <trans-unit id="form.group_general">
-        <source>form.group_general</source>
+      <trans-unit id="form.tab_general">
+        <source>form.tab_general</source>
         <target>Allgemein</target>
       </trans-unit>
       <trans-unit id="form.group_advanced">

--- a/Resources/translations/CmfRoutingBundle.en.xliff
+++ b/Resources/translations/CmfRoutingBundle.en.xliff
@@ -54,13 +54,29 @@
         <source>list.label_path</source>
         <target>URL</target>
       </trans-unit>
-      <trans-unit id="form.group_general">
-        <source>form.group_general</source>
+      <trans-unit id="form.tab_general">
+        <source>form.tab_general</source>
         <target>General</target>
       </trans-unit>
-      <trans-unit id="form.group_advanced">
-        <source>form.group_advanced</source>
-        <target>Advanced</target>
+      <trans-unit id="form.tab_routing">
+        <source>form.tab_routing</source>
+        <target>Routing</target>
+      </trans-unit>
+      <trans-unit id="form.group_location">
+        <source>form.group_location</source>
+        <target>Location</target>
+      </trans-unit>
+      <trans-unit id="form.group_content">
+        <source>form.group_content</source>
+        <target>Content</target>
+      </trans-unit>
+      <trans-unit id="form.group_routing">
+        <source>form.group_path</source>
+        <target>Path</target>
+      </trans-unit>
+      <trans-unit id="form.group_data">
+        <source>form.group_data</source>
+        <target>Data</target>
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>

--- a/Resources/translations/CmfRoutingBundle.fr.xliff
+++ b/Resources/translations/CmfRoutingBundle.fr.xliff
@@ -54,8 +54,8 @@
         <source>list.label_path</source>
         <target>URL</target>
       </trans-unit>
-      <trans-unit id="form.group_general">
-        <source>form.group_general</source>
+      <trans-unit id="form.tab_general">
+        <source>form.tab_general</source>
         <target>Général</target>
       </trans-unit>
       <trans-unit id="form.group_advanced">

--- a/Resources/translations/CmfRoutingBundle.it.xliff
+++ b/Resources/translations/CmfRoutingBundle.it.xliff
@@ -54,8 +54,8 @@
         <source>list.label_path</source>
         <target>URL</target>
       </trans-unit>
-      <trans-unit id="form.group_general">
-        <source>form.group_general</source>
+      <trans-unit id="form.tab_general">
+        <source>form.tab_general</source>
         <target>Generale</target>
       </trans-unit>
       <trans-unit id="form.group_advanced">

--- a/Resources/translations/CmfRoutingBundle.nl.xliff
+++ b/Resources/translations/CmfRoutingBundle.nl.xliff
@@ -54,9 +54,29 @@
         <source>list.label_path</source>
         <target>URL</target>
       </trans-unit>
-      <trans-unit id="form.group_general">
-        <source>form.group_general</source>
+      <trans-unit id="form.tab_general">
+        <source>form.tab_general</source>
         <target>Algemeen</target>
+      </trans-unit>
+      <trans-unit id="form.tab_routing">
+        <source>form.tab_routing</source>
+        <target>Routing</target>
+      </trans-unit>
+      <trans-unit id="form.group_location">
+        <source>form.group_location</source>
+        <target>Locatie</target>
+      </trans-unit>
+      <trans-unit id="form.group_content">
+        <source>form.group_content</source>
+        <target>Content</target>
+      </trans-unit>
+      <trans-unit id="form.group_routing">
+        <source>form.group_routing</source>
+        <target>Routing</target>
+      </trans-unit>
+      <trans-unit id="form.group_data">
+        <source>form.group_data</source>
+        <target>Data</target>
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>

--- a/Resources/translations/CmfRoutingBundle.pl.xliff
+++ b/Resources/translations/CmfRoutingBundle.pl.xliff
@@ -54,8 +54,8 @@
         <source>list.label_path</source>
         <target>URL</target>
       </trans-unit>
-      <trans-unit id="form.group_general">
-        <source>form.group_general</source>
+      <trans-unit id="form.tab_general">
+        <source>form.tab_general</source>
         <target>Ogólne</target>
       </trans-unit>
       <trans-unit id="form.label_parent">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This should also work under SonataAdminBundle <2.3. This'll use both groups (columns) and tabs in the admin panel, improving the UX a lot :)

I've only reviewed it as parent of the SimpleCms admin, that's why I tagged it as WIP.

This requires https://github.com/sonata-project/SonataAdminBundle/pull/2615 to be merged.

See https://github.com/symfony-cmf/SimpleCmsBundle/pull/131 for an example.