### PR TITLE
WIP conditional enhancers

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@
 namespace Symfony\Cmf\Bundle\RoutingBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
@@ -77,9 +78,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('route_collection_limit')->defaultValue(0)->end()
                         ->scalarNode('generic_controller')->defaultNull()->end()
                         ->scalarNode('default_controller')->defaultNull()->end()
-                        ->append($this->methodAwareValues('controllers_by_type'))
-                        ->append($this->methodAwareValues('controllers_by_class'))
-                        ->append($this->methodAwareValues('templates_by_class'))
+                        ->append($this->httpMethodAwareValues('controllers_by_type'))
+                        ->append($this->httpMethodAwareValues('controllers_by_class'))
+                        ->append($this->httpMethodAwareValues('templates_by_class'))
                         ->arrayNode('persistence')
                             ->addDefaultsIfNotSet()
                             ->validate()
@@ -189,7 +190,14 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
-    public function methodAwareValues($name)
+    /**
+     * Build a node for a value with a possible HTTP method restriction.
+     *
+     * @param string $name
+     *
+     * @return NodeDefinition
+     */
+    private function httpMethodAwareValues($name)
     {
         $builder = new TreeBuilder();
         $node = $builder->root($name);
@@ -200,7 +208,7 @@ class Configuration implements ConfigurationInterface
                 ->beforeNormalization()
                     ->ifString()
                     ->then(function ($v) {
-                        return [['methods' => ['any'], 'value' => $v]];
+                        return array('value' => $v);
                     })
                 ->end()
                 ->validate()
@@ -219,6 +227,6 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('value')->end()
                 ->end()
             ->end()
-            ;
+        ;
     }
 }

--- a/Tests/Resources/Fixtures/config/config.yml
+++ b/Tests/Resources/Fixtures/config/config.yml
@@ -17,10 +17,7 @@ cmf_routing:
               -
                 methods: [any]
                 value: service:readMethod
-            Other\Class:
-              -
-                methods: [any]
-                value: service:method
+            Other\Class: service:method
         templates_by_class:
             Symfony\Cmf\Bundle\ContentBundle\Document\StaticContent: CmfContentBundle:StaticContent:index.html.twig
         persistence:

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -42,24 +42,24 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'generic_controller' => 'acme_main.controller:mainAction',
                 'controllers_by_type' => array(
                     'editable' => array(
-                        array('methods' => array('any'), 'value' => 'acme_main.some_controller:editableAction'),
+                        array('value' => 'acme_main.some_controller:editableAction'),
                     ),
                 ),
                 'controllers_by_class' => array(
                     'Symfony\Cmf\Bundle\ContentBundle\Document\StaticContent' => array(
-                        array('methods' => ['any'], 'value' => 'cmf_content.controller:indexAction'),
+                        array('value' => 'cmf_content.controller:indexAction'),
                     ),
                     'My\Class' => array(
                         array('methods' => array('put', 'post'), 'value' => 'service:method'),
                         array('methods' => array('any'), 'value' => 'service:readMethod'),
                     ),
                     'Other\Class' => array(
-                        array('methods' => array('any'), 'value' => 'service:method'),
+                        array('value' => 'service:method'),
                     ),
                 ),
                 'templates_by_class' => array(
                     'Symfony\Cmf\Bundle\ContentBundle\Document\StaticContent' => array(
-                        array('methods' => array('any'), 'value' => 'CmfContentBundle:StaticContent:index.html.twig'),
+                        array('value' => 'CmfContentBundle:StaticContent:index.html.twig'),
                     ),
                 ),
                 'persistence' => array(

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^5.3.9|^7.0",
-        "symfony-cmf/routing": "dev-adder_conditional_enhancer",
+        "symfony-cmf/routing": "^1.4.0",
         "symfony/framework-bundle": "~2.3"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -


I spent quite some time on this until i realized what you tried to explain to me @ElectricMaxxx .

before, we had e.g. one enhancer for the controller by class map. now we would need a conditional enhancer per entry in that map with a field by class enhancer per method. this is indeed super inefficient and cumbersome.

an easy solution could be to swap the configuration. if we had this:

```yaml
controllers_by_class:
    - 
        methods: put
        map:
            My\Class: service:method
    - 
        methods: any
        map:
            My\Class: service:readMethod
            Other\Class: service:method    
```

this is a bit less readable and a bit confusing, but would reduce the overhead tremendously.

i pondered rearranging the mapping to group it by method, but with the "any" entries, this could change behaviour if we have this:

```yaml
controllers_by_class:
    My\ChildClass:
        - 
            methods: [any]
            value: cmf_content.controller:indexAction
    My\ParentClass:
        -
            methods: [put, post]
            value: service:method
```

if we first execute the put, post matcher, we end up with service:method for the child class, instead of the any that was specific to ChildClass. with the new configuration, this will be explicit and can be noticed and adressed by adding specific entries for ChildClass.