### PR TITLE
declare conflict with phpcr-odm 1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
 
         "sonata-project/doctrine-phpcr-admin-bundle": "To provide an admin interface for the PHPCR ODM documents (^1.1)"
     },
+    "conflict": {
+        "doctrine/phpcr-odm": "<2.0"
+    },
     "autoload": {
         "psr-4": {
             "Symfony\\Cmf\\Bundle\\RoutingBundle\\": ""


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

since removing the getParent method from the Route document, we conflict with phpcr-odm 1.* that had this in its interface