### PR TITLE
Fixed typo in extends usage of PHPUnit_Framework_TestCase in 3 tests

### DIFF
--- a/Tests/Unit/Doctrine/Phpcr/ContentRepositoryTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/ContentRepositoryTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Unit\Doctrine\Phpcr;
 
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\ContentRepository;
 
-class ContentRepositoryTest extends \PHPUnit_Framework_Testcase
+class ContentRepositoryTest extends \PHPUnit_Framework_TestCase
 {
     private $document;
     private $document2;

--- a/Tests/Unit/Doctrine/Phpcr/RouteTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/RouteTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Unit\Doctrine\Phpcr;
 
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route;
 
-class RouteTest extends \PHPUnit_Framework_Testcase
+class RouteTest extends \PHPUnit_Framework_TestCase
 {
     /** @var Route */
     private $route;

--- a/Tests/Unit/Form/Type/RouteTypeTypeTest.php
+++ b/Tests/Unit/Form/Type/RouteTypeTypeTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Unit\Form\Type;
 use Symfony\Cmf\Bundle\RoutingBundle\Form\Type\RouteTypeType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class RouteTypeTypeTest extends \PHPUnit_Framework_Testcase
+class RouteTypeTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

