### PR TITLE
Add option to use custom Route class in ORM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+ * **2016-10-10**: [ORM] Add option to use custom Route class in ORM
  * **2016-06-18**: [BC BREAK] Removed all `*.class` parameters.
  * **2016-06-18**: [BC BREAK] Removed the `cmf_routing.dynamic.persistence.phpcr.route_basepath`
    setting.

--- a/CmfRoutingBundle.php
+++ b/CmfRoutingBundle.php
@@ -96,8 +96,19 @@ class CmfRoutingBundle extends Bundle
                     realpath(__DIR__.'/Resources/config/doctrine-orm') => 'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm',
                 ),
                 array('cmf_routing.dynamic.persistence.orm.manager_name'),
-                'cmf_routing.backend_type_orm',
+                'cmf_routing.backend_type_orm_default',
                 array('CmfRoutingBundle' => 'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm')
+            )
+        );
+
+        $container->addCompilerPass(
+            $doctrineOrmCompiler::createXmlMappingDriver(
+                array(
+                    realpath(__DIR__.'/Resources/config/doctrine-model') => 'Symfony\Cmf\Bundle\RoutingBundle\Model',
+                ),
+                array('cmf_routing.dynamic.persistence.orm.manager_name'),
+                'cmf_routing.backend_type_orm_custom',
+                array()
             )
         );
     }

--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\RoutingBundle\DependencyInjection;
 
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -282,6 +283,12 @@ class CmfRoutingExtension extends Extension
 
         $container->setParameter('cmf_routing.backend_type_orm', true);
         $container->setParameter('cmf_routing.dynamic.persistence.orm.manager_name', $config['manager_name']);
+        $container->setParameter('cmf_routing.dynamic.persistence.orm.route_class', $config['route_class']);
+        if ($config['route_class'] === Route::class) {
+            $container->setParameter('cmf_routing.backend_type_orm_default', true);
+        } else {
+            $container->setParameter('cmf_routing.backend_type_orm_custom', true);
+        }
 
         if (!$matchImplicitLocale) {
             // remove the locales argument from the candidates

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Bundle\RoutingBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route;
 
 /**
  * This class contains the configuration information for the bundle.
@@ -163,6 +164,7 @@ class Configuration implements ConfigurationInterface
                                     ->canBeEnabled()
                                     ->children()
                                         ->scalarNode('manager_name')->defaultNull()->end()
+                                        ->scalarNode('route_class')->defaultValue(Route::class)->end()
                                     ->end()
                                 ->end() // orm
                             ->end()

--- a/Resources/config/provider-orm.xml
+++ b/Resources/config/provider-orm.xml
@@ -20,7 +20,7 @@
         <service id="cmf_routing.route_provider" class="Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\RouteProvider">
             <argument type="service" id="doctrine" />
             <argument type="service" id="cmf_routing.orm_candidates" />
-            <argument>Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route</argument>
+            <argument>%cmf_routing.dynamic.persistence.orm.route_class%</argument>
             <call method="setManagerName"><argument>%cmf_routing.dynamic.persistence.orm.manager_name%</argument></call>
             <call method="setRouteCollectionLimit"><argument>%cmf_routing.route_collection_limit%</argument></call>
         </service>

--- a/Tests/Unit/DependencyInjection/CmfRoutingExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/CmfRoutingExtensionTest.php
@@ -388,6 +388,36 @@ class CmfRoutingExtensionTest extends AbstractExtensionTestCase
         $this->assertTrue($this->container->has('cmf_routing.initializer'));
     }
 
+    public function testSettingCustomRouteClassForOrm()
+    {
+        $this->load(array(
+            'dynamic' => array(
+                'enabled' => true,
+                'persistence' => array(
+                    'orm' => array(
+                        'enabled' => true,
+                    ),
+                ),
+            ),
+        ));
+
+        $this->assertContainerBuilderHasParameter('cmf_routing.backend_type_orm_default', true);
+
+        $this->load(array(
+            'dynamic' => array(
+                'enabled' => true,
+                'persistence' => array(
+                    'orm' => array(
+                        'enabled' => true,
+                        'route_class' => 'Some\Bundle\CustomBundle\Doctrine\ORM\Route',
+                    ),
+                ),
+            ),
+        ));
+
+        $this->assertContainerBuilderHasParameter('cmf_routing.backend_type_orm_custom', true);
+    }
+
     public function testInitializerDisabledAutomaticallyIfSonataIsDisabled()
     {
         $this->load(array(

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -65,6 +65,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'orm' => array(
                         'enabled' => false,
                         'manager_name' => null,
+                        'route_class' => 'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route',
                     ),
                 ),
                 'enabled' => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | [symfony-cmf/symfony-cmf-docs#779](https://github.com/symfony-cmf/symfony-cmf-docs/pull/779)

As PHPCR easily allows you to add custom properties (and own class) to Route, this functionality ix missing in ORM implementation. This PR replaces hardcoded Route class name with configuration parameter and register doctrine mapping config pass for only needed directories. 

In case of custom Route class all what you need to do is adding `route_class` to orm config:
```
cmf_routing:
    ...
    dynamic:
        persistence:
            orm:
                enabled: true
                route_class: "SWP\\Bundle\\ContentBundle\\Doctrine\\ORM\\Route"
```

