### PR TITLE
Fix an issue where $condition columns are mapped on every entity during doctrine:generate:entities 

### DIFF
--- a/src/Doctrine/RouteConditionMetadataListener.php
+++ b/src/Doctrine/RouteConditionMetadataListener.php
@@ -50,7 +50,7 @@ class RouteConditionMetadataListener implements EventSubscriber
 
         $meta = $eventArgs->getClassMetadata();
         $refl = $meta->getReflectionClass();
-        if (null !== $refl && 'Symfony\Component\Routing\Route' !== $refl->getName()) {
+        if (null === $refl || 'Symfony\Component\Routing\Route' !== $refl->getName()) {
             return;
         }
 


### PR DESCRIPTION
Hi,

In my Symfony (3.2) project, when I run doctrine:generate:entities, on every Entity of my application there appears a new column $condition. This happened since I upgraded this bundle to 1.4 (back on Symfony 2.8), the problem remains when upgrading Symfony to 3.2, and I also updated this bundle to 2.0.

This seems to occur in `src/Doctrine/RouteConditionMetadataListener.php::loadClassMetadata`. I tried to debug this, and when my Entities go through this loop, the $refl variable is being set to `null`, which allows them to continue, and append a new $condition column, which seems wrong.

Can anybody check if this change would break the expected behaviour (tests pass), and if this change correctly fixes the issue. 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 
