### PR TITLE
Keep support for PHPCR-ODM 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,23 +14,19 @@ cache:
 
 env:
   matrix:
-    - SYMFONY_VERSION=3.1.*
+    - SYMFONY_VERSION=3.2.*
   global:
     - SYMFONY_DEPRECATIONS_HELPER=231
-    - SYMFONY_PHPUNIT_REMOVE="symfony/yaml"
-    - SYMFONY_PHPUNIT_DIR="./.phpunit"
-    - SYMFONY_PHPUNIT_VERSION=5.7
+    - SYMFONY_PHPUNIT_REMOVE="symfony/yaml" SYMFONY_PHPUNIT_DIR="./.phpunit" SYMFONY_PHPUNIT_VERSION=5.7
 
 matrix:
   include:
-    - php: 7.0
+    - php: 7.1
       env: DEPS=dev SYMFONY_VERSION=3.3.*
     - php: 5.6
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 7.0
-      env: SYMFONY_VERSION=3.0.*
-    - php: 7.0
-      env: SYMFONY_VERSION=3.2.*
+    - php: 7.1
+      env: SYMFONY_VERSION=3.1.*
   fast_finish: true
 
 before_install:
@@ -48,4 +44,3 @@ script: vendor/bin/simple-phpunit
 
 notifications:
   irc: "irc.freenode.org#symfony-cmf"
-  email: "symfony-cmf-devs@googlegroups.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
- * **2016-12-02**: [BC BREAK] Move all sonata related code
+ * **2016-12-02**: [BC BREAK] Moved all sonata related code to sonata-phpcr-admin-integration-bundle
  * **2016-10-10**: [ORM] Add option to use custom Route class in ORM
  * **2016-06-18**: [BC BREAK] Removed all `*.class` parameters.
  * **2016-06-18**: [BC BREAK] Removed the `cmf_routing.dynamic.persistence.phpcr.route_basepath`

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,11 @@
     "require-dev": {
         "symfony-cmf/core-bundle": "^2.0",
         "symfony-cmf/testing": "^2.0",
-        "doctrine/phpcr-odm": "^2.0",
+        "doctrine/phpcr-odm": "^1.4|^2.0",
         "symfony/phpunit-bridge": "^3.2",
         "matthiasnoback/symfony-dependency-injection-test": "~0.6",
         "matthiasnoback/symfony-config-test": "^1.3.1",
         "phpunit/php-code-coverage": "@stable",
-        "sonata-project/admin-bundle": "^2.3.7|^3.0",
-        "sonata-project/block-bundle": "^2.2.8|^3.0",
-        "sonata-project/core-bundle": "^2.2.5|^3.0",
         "symfony/monolog-bundle": "^2.3|^3.0",
         "doctrine/orm": "^2.5",
         "doctrine/data-fixtures": "^1.0.0"
@@ -34,17 +31,14 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "suggest": {
-        "doctrine/phpcr-odm": "To enable support for the PHPCR ODM documents (^1.3)",
+        "doctrine/phpcr-odm": "To enable support for the PHPCR ODM documents (^1.4)",
         "doctrine/phpcr-bundle": "To enable support for the PHPCR ODM documents",
         "doctrine/orm": "To enable support for the ORM entities (^2.5)",
-
         "symfony-cmf/content-bundle": "To optionally use the configured value for 'content_basepath' from the CoreBundle",
-        "symfony-cmf/core-bundle": "To use the provided Doctrine\\Phpcr documents and for easier configuration (^1.1)",
-
-        "symfony-cmf/sonata-admin-integration": "To provide an admin interface for the PHPCR ODM documents (^1.1)"
+        "symfony-cmf/core-bundle": "To use the RouteTypeType form type and for easier configuration (^2.0)"
     },
     "conflict": {
-        "doctrine/phpcr-odm": "<2.0"
+        "doctrine/phpcr-odm": "<1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Doctrine/Phpcr/RedirectRoute.php
+++ b/src/Doctrine/Phpcr/RedirectRoute.php
@@ -100,6 +100,8 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      */
     public function setParent($parent)
     {
+        @trigger_error('The '.__METHOD__.'() method is deprecated and will be removed in version 3.0. Use setParentDocument() instead.', E_USER_DEPRECATED);
+
         return $this->setParentDocument($parent);
     }
 
@@ -109,6 +111,8 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      */
     public function getParent()
     {
+        @trigger_error('The '.__METHOD__.'() method is deprecated and will be removed in version 3.0. Use getParentDocument() instead.', E_USER_DEPRECATED);
+
         return $this->getParentDocument();
     }
 

--- a/src/Doctrine/Phpcr/RedirectRoute.php
+++ b/src/Doctrine/Phpcr/RedirectRoute.php
@@ -95,6 +95,24 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
     }
 
     /**
+     * @deprecated For BC with the PHPCR-ODM 1.4 HierarchyInterface
+     * @see setParentDocument
+     */
+    public function setParent($parent)
+    {
+        return $this->setParentDocument($parent);
+    }
+
+    /**
+     * @deprecated For BC with the PHPCR-ODM 1.4 HierarchyInterface
+     * @see getParentDocument
+     */
+    public function getParent()
+    {
+        return $this->getParentDocument();
+    }
+
+    /**
      * Rename a route by setting its new name.
      *
      * Note that this will change the URL this route matches.

--- a/src/Doctrine/Phpcr/Route.php
+++ b/src/Doctrine/Phpcr/Route.php
@@ -110,6 +110,8 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      */
     public function setParent($parent)
     {
+        @trigger_error('The '.__METHOD__.'() method is deprecated and will be removed in version 3.0. Use setParentDocument() instead.', E_USER_DEPRECATED);
+
         return $this->setParentDocument($parent);
     }
 
@@ -119,6 +121,8 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      */
     public function getParent()
     {
+        @trigger_error('The '.__METHOD__.'() method is deprecated and will be removed in version 3.0. Use getParentDocument() instead.', E_USER_DEPRECATED);
+
         return $this->getParentDocument();
     }
 

--- a/src/Doctrine/Phpcr/Route.php
+++ b/src/Doctrine/Phpcr/Route.php
@@ -105,6 +105,24 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
     }
 
     /**
+     * @deprecated For BC with the PHPCR-ODM 1.4 HierarchyInterface
+     * @see setParentDocument
+     */
+    public function setParent($parent)
+    {
+        return $this->setParentDocument($parent);
+    }
+
+    /**
+     * @deprecated For BC with the PHPCR-ODM 1.4 HierarchyInterface
+     * @see getParentDocument
+     */
+    public function getParent()
+    {
+        return $this->getParentDocument();
+    }
+
+    /**
      * Rename a route by setting its new name.
      *
      * Note that this will change the URL this route matches.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -


as discussed on slack, lets keep support for phpcr-odm 1.4 so we can release without needing phpcr-odm 2.0 first.