### PR TITLE
remove unused content_basepath from phpcr configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+ * **2017-02-03**: [BC BREAK] Removed unused `cmf_routing.dynamic.persistence.phpcr.content_basepath`
+
 2.0.0-RC1
 ---------
 

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -68,6 +68,51 @@
                            - cmf_sonata_admin_integration.routing.redirect_route_admin
    ```
 
+ * The settings `admin_basepath` and `content_basepath` are only relevant for the admin and thus have been moved as well.
+
+   **Before**
+   ```yaml
+   cmf_routing:
+       # ...
+       dynamic:
+           persistence:
+               phpcr:
+                   admin_basepath: '/cms/routes'
+                   content_basepath: '/cms/content'
+   ```
+   ```xml
+   <config xmlns="http://cmf.symfony.com/schema/dic/routing">
+       <dynamic>
+           <persistence>
+               <phpcr
+                   admin-basepath="/cms/routes"
+                   content-basepath="/cms/content"
+                />
+           </persistence>
+       </dynamic>
+   </config>
+   ```
+
+   **After**
+   ```yaml
+   cmf_sonata_phpcr_admin_integration:
+       # ...
+       bundles:
+           routing:
+               basepath: '/cms/routes'
+               content_basepath: '/cms/content'
+   ```
+   ```xml
+   <config xmlns="http://cmf.symfony.com/schema/dic/sonata-phpcr-admin-integration">
+       <bundles>
+           <routing
+               basepath="/cms/routes"
+               content-basepath="/cms/content"
+            />
+       </bundles>
+   </config>
+   ```
+
 ## Route Model
 
  * Removed `getAddFormatPattern()`/`setAddFormatPattern()` from the model

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,7 @@
     "suggest": {
         "doctrine/phpcr-odm": "To enable support for the PHPCR ODM documents (^1.4)",
         "doctrine/phpcr-bundle": "To enable support for the PHPCR ODM documents",
-        "doctrine/orm": "To enable support for the ORM entities (^2.5)",
-        "symfony-cmf/content-bundle": "To optionally use the configured value for 'content_basepath' from the CoreBundle"
+        "doctrine/orm": "To enable support for the ORM entities (^2.5)"
     },
     "conflict": {
         "doctrine/phpcr-odm": "<1.4"

--- a/src/DependencyInjection/CmfRoutingExtension.php
+++ b/src/DependencyInjection/CmfRoutingExtension.php
@@ -214,7 +214,6 @@ class CmfRoutingExtension extends Extension
         $container->setParameter('cmf_routing.backend_type_phpcr', true);
         $container->setParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths', array_values(array_unique($config['route_basepaths'])));
 
-        $container->setParameter('cmf_routing.dynamic.persistence.phpcr.content_basepath', $config['content_basepath']);
         $container->setParameter('cmf_routing.dynamic.persistence.phpcr.manager_name', $config['manager_name']);
 
         if (0 === count($locales)) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -117,7 +117,6 @@ class Configuration implements ConfigurationInterface
                                             ->prototype('scalar')->end()
                                             ->defaultValue(['/cms/routes'])
                                         ->end() // route_basepaths
-                                        ->scalarNode('content_basepath')->defaultValue('/cms/content')->end()
                                         ->booleanNode('enable_initializer')
                                             ->defaultValue(true)
                                         ->end()

--- a/src/Resources/config/schema/routing-1.0.xsd
+++ b/src/Resources/config/schema/routing-1.0.xsd
@@ -82,7 +82,6 @@
 
         <xsd:attribute name="enabled" type="xsd:boolean" />
         <xsd:attribute name="manager-name" type="xsd:string" />
-        <xsd:attribute name="content-basepath" type="xsd:string" />
         <xsd:attribute name="enable-initializer" type="xsd:boolean" />
     </xsd:complexType>
 

--- a/tests/Resources/Fixtures/config/config.php
+++ b/tests/Resources/Fixtures/config/config.php
@@ -34,7 +34,6 @@ $container->loadFromExtension('cmf_routing', [
                     '/cms/routes',
                     '/simple',
                 ],
-                'content_basepath' => '/cms/content',
                 'enable_initializer' => true,
             ],
         ],

--- a/tests/Resources/Fixtures/config/config.xml
+++ b/tests/Resources/Fixtures/config/config.xml
@@ -23,7 +23,6 @@
 
             <persistence>
                 <phpcr
-                    content-basepath="/cms/content"
                     enable-initializer="true"
                 >
                     <route-basepath>/cms/routes</route-basepath>

--- a/tests/Resources/Fixtures/config/config.yml
+++ b/tests/Resources/Fixtures/config/config.yml
@@ -17,7 +17,6 @@ cmf_routing:
                 route_basepaths:
                     - /cms/routes
                     - /simple
-                content_basepath: /cms/content
                 enable_initializer: true
         locales: [en, fr]
         auto_locale_pattern: true

--- a/tests/Resources/Fixtures/config/config3.xml
+++ b/tests/Resources/Fixtures/config/config3.xml
@@ -3,7 +3,6 @@
         <persistence>
             <phpcr
                 manager-name="default"
-                content-basepath="/cms/content"
                 enable-initializer="true"
             >
                 <route-basepath>/cms/routes</route-basepath>

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -56,7 +56,6 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                             '/cms/routes',
                             '/simple',
                         ],
-                        'content_basepath' => '/cms/content',
                         'manager_name' => null,
                         'enable_initializer' => true,
                     ],


### PR DESCRIPTION
this configuration is only used in the sonata admin

| Q             | A
| ------------- | ---
| Bug fix?      | [yes]
| New feature?  | [no]
| BC breaks?    | [yes]
| Deprecations? | [no]
| Tests pass?   | [yes]
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/symfony-cmf/symfony-cmf-docs/pull/814
