### PR TITLE
do not rename the template in dynamic router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+ * **2017-02-06**: [BC BREAK] The `_template` request parameter will be renamed
+   to the `template` attribute instead of the `contentTemplate` attribute. The
+   old attribute will still be available for backwards compatibility.
  * **2017-02-03**: [BC BREAK] Removed unused `cmf_routing.dynamic.persistence.phpcr.content_basepath`
 
 2.0.0-RC1

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -21,7 +21,7 @@
                          - Symfony\Cmf\Component\Routing\RouteReferrersReadInterface
    ```
 
-    After:
+   After:
        
    ```yaml
         # app/config/config.yml
@@ -53,7 +53,7 @@
                            - cmf_routing.redirect_route_admin
    ```
 
-    After:
+   After:
        
    ```yaml
         # app/config/config.yml
@@ -70,7 +70,8 @@
 
  * The settings `admin_basepath` and `content_basepath` are only relevant for the admin and thus have been moved as well.
 
-   **Before**
+   Before:
+
    ```yaml
    cmf_routing:
        # ...
@@ -93,7 +94,8 @@
    </config>
    ```
 
-   **After**
+   After:
+
    ```yaml
    cmf_sonata_phpcr_admin_integration:
        # ...
@@ -113,14 +115,15 @@
    </config>
    ```
 
-## Route Model
+### Route Model
 
  * Removed `getAddFormatPattern()`/`setAddFormatPattern()` from the model
    `Route` and `getAddTrailingSlash()`/`setAddTrailingSlash()` from the PHPCR
    `Route`. Use `getOption()`/`setOption()` with `'add_format_pattern'` or
    `'add_trailing_slash'` instead.
 
-   **Before**
+   Before:
+
    ```php
    $route->setAddFormatPattern(true);
    $route->setAddTrailingSlash(true);
@@ -130,7 +133,8 @@
    }
    ```
 
-   **After**
+   After:
+
    ```php
    $route->setOption('add_format_pattern', true);
    $route->setOption('add_trailing_slash', true);
@@ -143,23 +147,26 @@
  * Removed `getParent()`/`setParent()` from PHPCR `Route` and `RedirectRoute`.
    Use `getParentDocument()`/`setParentDocument()` instead.
 
-   **Before**
+   Before:
+
    ```php
    $route = new Route();
    $route->setParent($routeRoot);
    ```
 
-   **After**
+   After:
+
    ```php
    $route = new Route();
    $route->setParentDocument($routeRoot);
    ```
 
-## Configuration
+### Configuration
 
  * Removed the `route_basepath` setting, use `route_basepaths` instead.
 
-   **Before**
+   Before:
+
    ```yaml
    cmf_routing:
        # ...
@@ -178,7 +185,8 @@
    </config>
    ```
 
-   **After**
+   After:
+
    ```yaml
    cmf_routing:
        # ...
@@ -198,3 +206,29 @@
        </dynamic>
    </config>
    ```
+
+### Route Template
+
+ * The `contentTemplate` request attribute is deprecated in favor of
+   `template`. The CmfContentBundle has been adjusted accordingly.
+
+   Before:
+
+   ```php
+   public function documentAction($contentDocument, $contentTemplate)
+   {
+       // ...
+   }
+   ```
+
+   After:
+
+   ```php
+   public function documentAction($contentDocument, $template)
+   {
+       // ...
+   }
+   ```
+   
+   The deprecated `contentTemplate` will be kept for backwards compatibility
+   and will be removed in version 3.0.

--- a/src/Routing/DynamicRouter.php
+++ b/src/Routing/DynamicRouter.php
@@ -41,7 +41,7 @@ class DynamicRouter extends BaseDynamicRouter
      * key for the request attribute that contains the template this document
      * wants to use.
      */
-    const CONTENT_TEMPLATE = 'contentTemplate';
+    const CONTENT_TEMPLATE = 'template';
 
     /**
      * @var Request
@@ -99,6 +99,10 @@ class DynamicRouter extends BaseDynamicRouter
 
         if (array_key_exists(RouteObjectInterface::TEMPLATE_NAME, $defaults)) {
             $request->attributes->set(self::CONTENT_TEMPLATE, $defaults[RouteObjectInterface::TEMPLATE_NAME]);
+
+            // contentTemplate is deprecated as of version 2.0, to be removed in 3.0
+            $request->attributes->set('contentTemplate', $defaults[RouteObjectInterface::TEMPLATE_NAME]);
+
             unset($defaults[RouteObjectInterface::TEMPLATE_NAME]);
         }
 


### PR DESCRIPTION
$template is in line with the FrameworkBundle TemplateController

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | travis-ci
| Fixed tickets | -
| License       | MIT
| Doc PR        | TODO

together with https://github.com/symfony-cmf/content-bundle/pull/174