### PR TITLE
Added child restriction to Route & RedirectRoute documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+ * **2017-02-09**: [BC BREAK] Added child restrictions to the `Route` and `RedirectRoute` documents.
+   See the UPGRADE guide for detailed information.
  * **2017-02-03**: [BC BREAK] Removed unused `cmf_routing.dynamic.persistence.phpcr.content_basepath`
 
 2.0.0-RC1

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -155,6 +155,16 @@
    $route->setParentDocument($routeRoot);
    ```
 
+## Doctrine PHPCR ODM
+
+ * It is no longer possible to add a child to the `RedirectRoute` document.
+   This behaviour can be changed by overriding the `child-class` setting of the
+   PHPCR ODM mapping.
+
+ * Only instances of `RouteObjectInterface` are allowed as children of the
+   `Route` document. This behaviour can be changed by overriding the
+   `child-class` setting of the PHPCR ODM mapping.
+
 ## Configuration
 
  * Removed the `route_basepath` setting, use `route_basepaths` instead.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "symfony-cmf/testing": "^2.0",
-        "doctrine/phpcr-odm": "^1.4|^2.0",
+        "doctrine/phpcr-odm": "^1.4.2",
         "symfony/phpunit-bridge": "^3.2",
         "matthiasnoback/symfony-dependency-injection-test": "~0.6",
         "matthiasnoback/symfony-config-test": "^1.3.1",

--- a/src/Resources/config/doctrine-phpcr/RedirectRoute.phpcr.xml
+++ b/src/Resources/config/doctrine-phpcr/RedirectRoute.phpcr.xml
@@ -5,7 +5,7 @@
     https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd"
 >
 
-    <document name="Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute">
+    <document name="Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute" is-leaf="true">
         <id name="id">
             <generator strategy="PARENT"/>
         </id>

--- a/src/Resources/config/doctrine-phpcr/Route.phpcr.xml
+++ b/src/Resources/config/doctrine-phpcr/Route.phpcr.xml
@@ -13,6 +13,7 @@
         <nodename name="name"/>
         <parent-document name="parent"/>
         <children name="children"/>
+        <child-class name="Symfony\Cmf\Component\Routing\RouteObjectInterface"/>
     </document>
 
 </doctrine-mapping>

--- a/tests/Functional/Doctrine/Phpcr/RedirectRouteTest.php
+++ b/tests/Functional/Doctrine/Phpcr/RedirectRouteTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Functional\Doctrine\Phpcr;
 
+use Doctrine\ODM\PHPCR\Document\Generic;
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute;
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route;
 use Symfony\Cmf\Bundle\RoutingBundle\Tests\Functional\BaseTestCase;
@@ -21,7 +22,7 @@ class RedirectRouteTest extends BaseTestCase
 {
     const ROUTE_ROOT = '/test/redirectroute';
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->db('PHPCR')->createTestNode();
@@ -57,6 +58,27 @@ class RedirectRouteTest extends BaseTestCase
         $this->assertSame($route, $redirect->getRouteTarget());
         $defaults = $redirect->getDefaults();
         $this->assertEquals(['test' => 'toast'], $defaults);
+    }
+
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\Exception\OutOfBoundsException
+     * @expectedExceptionMessage It cannot have children
+     */
+    public function testPersistChild()
+    {
+        $root = $this->getDm()->find(null, self::ROUTE_ROOT);
+
+        $redirect = new RedirectRoute();
+        $redirect->setPosition($root, 'redirect');
+        $redirect->setDefault('test', 'toast');
+        $this->getDm()->persist($redirect);
+
+        $child = new Generic();
+        $child->setParentDocument($redirect);
+        $child->setNodename('foo');
+        $this->getDm()->persist($child);
+
+        $this->getDm()->flush();
     }
 
     /**

--- a/tests/Functional/Doctrine/Phpcr/RouteProviderTest.php
+++ b/tests/Functional/Doctrine/Phpcr/RouteProviderTest.php
@@ -26,7 +26,7 @@ class RouteProviderTest extends BaseTestCase
     /** @var RouteProvider */
     private $repository;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->db('PHPCR')->createTestNode();

--- a/tests/Functional/Doctrine/Phpcr/RouteTest.php
+++ b/tests/Functional/Doctrine/Phpcr/RouteTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Functional\Doctrine\Phpcr;
 
+use Doctrine\ODM\PHPCR\Document\Generic;
+use Doctrine\ODM\PHPCR\Exception\OutOfBoundsException;
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route;
 use Symfony\Cmf\Bundle\RoutingBundle\Tests\Functional\BaseTestCase;
 
@@ -18,7 +20,7 @@ class RouteTest extends BaseTestCase
 {
     const ROUTE_ROOT = '/test/routing';
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->db('PHPCR')->createTestNode();
@@ -87,6 +89,21 @@ class RouteTest extends BaseTestCase
         $this->assertTrue(1 >= count($options)); // there is a default option for the compiler
 
         return $route;
+    }
+
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\Exception\OutOfBoundsException
+     */
+    public function testPersistInvalidChild()
+    {
+        $root = $this->getDm()->find(null, self::ROUTE_ROOT);
+
+        $document = new Generic();
+        $document->setParentDocument($root);
+        $document->setNodeName('foo');
+
+        $this->getDm()->persist($document);
+        $this->getDm()->flush();
     }
 
     public function testConditionOption()


### PR DESCRIPTION
/fixes #386 

Builds are failing because of a bug in PHPCR ODM 1.4.0. The fix is already in master, but not yet released as 1.4.1.