### PR TITLE
use request stack rather than a single request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+ * **2017-02-17**: [BC BREAK] DynamicRouter::setRequest has been replaced with DynamicRouter::setRequestStack.
+
 2.0.0-RC2
 ---------
 

--- a/src/Resources/config/routing-dynamic.xml
+++ b/src/Resources/config/routing-dynamic.xml
@@ -61,7 +61,7 @@
             <argument>%cmf_routing.uri_filter_regexp%</argument>
             <argument type="service" id="event_dispatcher" on-invalid="ignore"/>
             <argument type="service" id="cmf_routing.route_provider"/>
-            <call method="setRequest"><argument type="service" id="request" on-invalid="null" strict="false"/></call>
+            <call method="setRequestStack"><argument type="service" id="request_stack"/></call>
         </service>
 
         <service id="cmf_routing.nested_matcher" class="Symfony\Cmf\Component\Routing\NestedMatcher\NestedMatcher">

--- a/src/Routing/DynamicRouter.php
+++ b/src/Routing/DynamicRouter.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Bundle\RoutingBundle\Routing;
 use Symfony\Cmf\Component\Routing\DynamicRouter as BaseDynamicRouter;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 /**
@@ -44,9 +45,9 @@ class DynamicRouter extends BaseDynamicRouter
     const CONTENT_TEMPLATE = 'template';
 
     /**
-     * @var Request
+     * @var RequestStack
      */
-    protected $request;
+    private $requestStack;
 
     /**
      * Put content and template name into the request attributes instead of the
@@ -110,24 +111,29 @@ class DynamicRouter extends BaseDynamicRouter
     }
 
     /**
-     * @param Request $request
+     * Set the request stack so that we can find the current request.
+     *
+     * @param RequestStack $requestStack
      */
-    public function setRequest(Request $request = null)
+    public function setRequestStack(RequestStack $requestStack)
     {
-        $this->request = $request;
+        $this->requestStack = $requestStack;
     }
 
     /**
+     * Get the current request from the request stack.
+     *
      * @return Request
      *
      * @throws \Symfony\Component\Routing\Exception\ResourceNotFoundException
      */
     public function getRequest()
     {
-        if (null === $this->request) {
-            throw new ResourceNotFoundException('Request object not available from container');
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        if (!$currentRequest) {
+            throw new ResourceNotFoundException('There is no request in the request stack');
         }
 
-        return $this->request;
+        return $currentRequest;
     }
 }


### PR DESCRIPTION
defaults to false in 2.8 and triggers deprecation since symfony 3.3

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | see travis
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

related to https://github.com/symfony/symfony/pull/21662