### PR TITLE
add dependencies for a clean install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
     "require": {
         "php": "^5.6|^7.0",
         "symfony-cmf/routing": "^2.0",
-        "symfony/framework-bundle": "^2.8|^3.0"
+        "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony/templating": "^2.8|^3.0",
+        "symfony/asset": "^2.8|^3.0",
+        "symfony/twig-bundle": "^2.8|^3.0"
     },
     "require-dev": {
         "symfony-cmf/testing": "^2.0",


### PR DESCRIPTION
I try to get a valid dependency situation, for installing routing bundle on its own with symfony >= 3.3