### PR TITLE
use twig loader to validate template's existence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.0.1
+-----
+
+* **2017-09-25**: This bundle can now also directly use the Twig loader instead of the deprecated templating
+  component. Symfony FrameworkBundle no longer requires symfony/templating since 3.2. If the templating component
+  is available in your application, it is however still used for BC.
+
 2.0.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": "^5.6|^7.0",
         "symfony-cmf/routing": "^2.0",
-        "symfony/framework-bundle": "^2.8|^3.0"
+        "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony/twig-bundle": "^2.8|^3.0"
     },
     "require-dev": {
         "symfony-cmf/testing": "^2.0",

--- a/src/CmfRoutingBundle.php
+++ b/src/CmfRoutingBundle.php
@@ -19,6 +19,7 @@ use Doctrine\ODM\PHPCR\Version as PHPCRVersion;
 use Doctrine\ORM\Mapping\Driver\XmlDriver as ORMXmlDriver;
 use Doctrine\ORM\Version as ORMVersion;
 use Symfony\Cmf\Bundle\RoutingBundle\DependencyInjection\Compiler\SetRouterPass;
+use Symfony\Cmf\Bundle\RoutingBundle\DependencyInjection\Compiler\TemplatingValidatorPass;
 use Symfony\Cmf\Bundle\RoutingBundle\DependencyInjection\Compiler\ValidationPass;
 use Symfony\Cmf\Component\Routing\DependencyInjection\Compiler\RegisterRouteEnhancersPass;
 use Symfony\Cmf\Component\Routing\DependencyInjection\Compiler\RegisterRoutersPass;
@@ -42,6 +43,7 @@ class CmfRoutingBundle extends Bundle
         $container->addCompilerPass(new RegisterRouteEnhancersPass());
         $container->addCompilerPass(new SetRouterPass());
         $container->addCompilerPass(new ValidationPass());
+        $container->addCompilerPass(new TemplatingValidatorPass());
 
         $this->buildPhpcrCompilerPass($container);
         $this->buildOrmCompilerPass($container);

--- a/src/DependencyInjection/Compiler/TemplatingValidatorPass.php
+++ b/src/DependencyInjection/Compiler/TemplatingValidatorPass.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\RoutingBundle\DependencyInjection\Compiler;
+
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Cmf\Bundle\RoutingBundle\Validator\Constraints\RouteDefaultsTemplatingValidator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * To avoid a BC-Break: If templating component exists, we will use the validator using general templating
+ * from FrameworkBundle.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class TemplatingValidatorPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (interface_exists(EngineInterface::class) && $container->has('templating')) {
+            $templatingDefinition = $container->findDefinition('templating');
+            $validatorDefinition = $container->getDefinition('cmf_routing.validator.route_defaults');
+            $validatorDefinition->setClass(RouteDefaultsTemplatingValidator::class);
+            $validatorDefinition->replaceArgument(1, $templatingDefinition);
+        }
+    }
+}

--- a/src/Doctrine/Phpcr/ContentRepository.php
+++ b/src/Doctrine/Phpcr/ContentRepository.php
@@ -41,6 +41,7 @@ class ContentRepository extends DoctrineProvider implements ContentRepositoryInt
         if (!is_object($content)) {
             return;
         }
+
         try {
             return $this->getObjectManager()->getUnitOfWork()->getDocumentId($content);
         } catch (\Exception $e) {

--- a/src/Doctrine/Phpcr/IdPrefixListener.php
+++ b/src/Doctrine/Phpcr/IdPrefixListener.php
@@ -76,6 +76,7 @@ class IdPrefixListener
             foreach ($this->getPrefixes() as $prefix) {
                 if (0 === strpos($doc->getId(), $prefix)) {
                     $doc->setPrefix($prefix);
+
                     break;
                 }
             }

--- a/src/Resources/config/validators.xml
+++ b/src/Resources/config/validators.xml
@@ -5,9 +5,12 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="cmf_routing.validator.route_defaults" class="Symfony\Cmf\Bundle\RoutingBundle\Validator\Constraints\RouteDefaultsValidator">
+        <service
+                id="cmf_routing.validator.route_defaults"
+                class="Symfony\Cmf\Bundle\RoutingBundle\Validator\Constraints\RouteDefaultsTwigValidator"
+        >
             <argument id="controller_resolver" type="service"/>
-            <argument id="templating" type="service"/>
+            <argument id="twig.loader" type="service"/>
             <tag name="validator.constraint_validator" alias="cmf_routing.validator.route_defaults" />
         </service>
     </services>

--- a/src/Validator/Constraints/RouteDefaultsTemplatingValidator.php
+++ b/src/Validator/Constraints/RouteDefaultsTemplatingValidator.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\RoutingBundle\Validator\Constraints;
+
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @deprecated Will be removed in 3.0. Use RouteDefaultsTwigValidator with twig as template engine instead.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class RouteDefaultsTemplatingValidator extends ConstraintValidator
+{
+    private $controllerResolver;
+
+    /**
+     * @var EngineInterface
+     */
+    private $templating;
+
+    public function __construct(ControllerResolverInterface $controllerResolver, EngineInterface $templating)
+    {
+        $this->controllerResolver = $controllerResolver;
+        $this->templating = $templating;
+    }
+
+    public function validate($defaults, Constraint $constraint)
+    {
+        if (isset($defaults['_controller']) && null !== $defaults['_controller']) {
+            $controller = $defaults['_controller'];
+
+            $request = new Request([], [], ['_controller' => $controller]);
+
+            try {
+                $this->controllerResolver->getController($request);
+            } catch (\LogicException $e) {
+                $this->context->addViolation($e->getMessage());
+            }
+        }
+
+        if (isset($defaults['_template']) && null !== $defaults['_template']) {
+            $template = $defaults['_template'];
+
+            if (false === $this->templating->exists($template)) {
+                $this->context->addViolation($constraint->message, ['%name%' => $template]);
+            }
+        }
+    }
+}

--- a/src/Validator/Constraints/RouteDefaultsTwigValidator.php
+++ b/src/Validator/Constraints/RouteDefaultsTwigValidator.php
@@ -11,21 +11,28 @@
 
 namespace Symfony\Cmf\Bundle\RoutingBundle\Validator\Constraints;
 
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Twig\Loader\LoaderInterface;
 
-class RouteDefaultsValidator extends ConstraintValidator
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@gmx.de>
+ */
+class RouteDefaultsTwigValidator extends ConstraintValidator
 {
     private $controllerResolver;
-    private $templating;
 
-    public function __construct(ControllerResolverInterface $controllerResolver, EngineInterface $templating)
+    /**
+     * @var LoaderInterface
+     */
+    private $twig;
+
+    public function __construct(ControllerResolverInterface $controllerResolver, LoaderInterface $twig)
     {
         $this->controllerResolver = $controllerResolver;
-        $this->templating = $templating;
+        $this->twig = $twig;
     }
 
     public function validate($defaults, Constraint $constraint)
@@ -45,7 +52,7 @@ class RouteDefaultsValidator extends ConstraintValidator
         if (isset($defaults['_template']) && null !== $defaults['_template']) {
             $template = $defaults['_template'];
 
-            if (false === $this->templating->exists($template)) {
+            if (false === $this->twig->exists($template)) {
                 $this->context->addViolation($constraint->message, ['%name%' => $template]);
             }
         }

--- a/tests/Unit/Validator/Constraints/RouteDefaultsTemplatingValidatorTest.php
+++ b/tests/Unit/Validator/Constraints/RouteDefaultsTemplatingValidatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Unit\Validator\Constraints;
+
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Cmf\Bundle\RoutingBundle\Validator\Constraints\RouteDefaultsTemplatingValidator;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+
+class RouteDefaultsTemplatingValidatorTest extends RouteDefaultsValidatorTest
+{
+    protected function setUp()
+    {
+        $this->controllerResolver = $this->createMock(ControllerResolverInterface::class);
+        $this->engine = $this->createMock(EngineInterface::class);
+
+        parent::setUp();
+    }
+
+    protected function createValidator()
+    {
+        return new RouteDefaultsTemplatingValidator($this->controllerResolver, $this->engine);
+    }
+}

--- a/tests/Unit/Validator/Constraints/RouteDefaultsTwigValidatorTest.php
+++ b/tests/Unit/Validator/Constraints/RouteDefaultsTwigValidatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Unit\Validator\Constraints;
+
+use Symfony\Cmf\Bundle\RoutingBundle\Validator\Constraints\RouteDefaultsTwigValidator;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Twig\Loader\LoaderInterface;
+
+class RouteDefaultsTwigValidatorTest extends RouteDefaultsValidatorTest
+{
+    protected function setUp()
+    {
+        $this->controllerResolver = $this->createMock(ControllerResolverInterface::class);
+        $this->engine = $this->createMock(LoaderInterface::class);
+
+        parent::setUp();
+    }
+
+    protected function createValidator()
+    {
+        return new RouteDefaultsTwigValidator($this->controllerResolver, $this->engine);
+    }
+}

--- a/tests/Unit/Validator/Constraints/RouteDefaultsValidatorTest.php
+++ b/tests/Unit/Validator/Constraints/RouteDefaultsValidatorTest.php
@@ -9,31 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Functional\Admin;
+namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Unit\Validator\Constraints;
 
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Cmf\Bundle\RoutingBundle\Validator\Constraints\RouteDefaults;
-use Symfony\Cmf\Bundle\RoutingBundle\Validator\Constraints\RouteDefaultsValidator;
-use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\Validator\Tests\Constraints\AbstractConstraintValidatorTest;
 
-class RouteDefaultsValidatorTest extends AbstractConstraintValidatorTest
+abstract class RouteDefaultsValidatorTest extends AbstractConstraintValidatorTest
 {
-    private $controllerResolver;
-    private $templating;
-
-    protected function setUp()
-    {
-        $this->controllerResolver = $this->createMock(ControllerResolverInterface::class);
-        $this->templating = $this->createMock(EngineInterface::class);
-
-        parent::setUp();
-    }
-
-    protected function createValidator()
-    {
-        return new RouteDefaultsValidator($this->controllerResolver, $this->templating);
-    }
+    protected $controllerResolver;
+    protected $engine;
 
     public function testCorrectControllerPath()
     {
@@ -56,7 +40,7 @@ class RouteDefaultsValidatorTest extends AbstractConstraintValidatorTest
 
     public function testCorrectTemplate()
     {
-        $this->templating->expects($this->any())
+        $this->engine->expects($this->any())
             ->method('exists')
             ->will($this->returnValue(true))
         ;
@@ -69,7 +53,7 @@ class RouteDefaultsValidatorTest extends AbstractConstraintValidatorTest
     public function testTemplateViolation()
     {
         $this
-            ->templating
+            ->engine
             ->expects($this->any())
             ->method('exists')
             ->will($this->returnValue(false))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [no]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | [no]
| Tests pass?   | [yes]
| Fixed tickets | [#396]
| License       | MIT

fix #396 

I  replaced templating by a twig loader based on the comment of @fabpot (maybe you can give us a internal in review)
https://github.com/symfony/recipes-contrib/pull/91#issuecomment-331666757

@dbu @wouterj I have no clue if we can release that on a patch release or if it is an BC-Break. From my POV we didn't change any external API, so a patch release would be ok. 
