### PR TITLE
Fix access of private router service since Symfony 3.4

### DIFF
--- a/src/DependencyInjection/Compiler/SetRouterPass.php
+++ b/src/DependencyInjection/Compiler/SetRouterPass.php
@@ -24,6 +24,7 @@ class SetRouterPass implements CompilerPassInterface
         // only replace the default router by overwriting the 'router' alias if config tells us to
         if ($container->hasParameter('cmf_routing.replace_symfony_router') && true === $container->getParameter('cmf_routing.replace_symfony_router')) {
             $container->setAlias('router', 'cmf_routing.router');
+            $container->getAlias('router')->setPublic(true);
         }
     }
 }


### PR DESCRIPTION
Services are private by default since Symfony 3.4. Since the router service is still directly accesses in various places it needs to be explicitly marked as `public` to prevent deprecations in Symfony 3.4 and errors in Symfony 4.0.

| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
