### PR TITLE
Removed usage of the deprecated `each` function

### DIFF
--- a/src/Form/Type/RouteTypeType.php
+++ b/src/Form/Type/RouteTypeType.php
@@ -18,6 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class RouteTypeType extends AbstractType
 {
     protected $routeTypes = [];
+
     protected $translator;
 
     /**

--- a/tests/Functional/Doctrine/Phpcr/RouteProviderTest.php
+++ b/tests/Functional/Doctrine/Phpcr/RouteProviderTest.php
@@ -66,17 +66,21 @@ class RouteProviderTest extends BaseTestCase
         $this->assertCount(3, $routes);
         $this->assertContainsOnlyInstancesOf(RouteObjectInterface::class, $routes);
 
-        $route = $routes->get(self::ROUTE_ROOT.'/testroute/noroute/child');
-        $this->assertNotNull($route);
-        $this->assertEquals('json', $route->getDefault('_format'));
+        $iterator = $routes->getIterator();
 
-        $route = $routes->get(self::ROUTE_ROOT.'/testroute');
-        $this->assertNotNull($route);
-        $this->assertEquals('html', $route->getDefault('_format'));
+        $this->assertTrue($iterator->valid());
+        $this->assertEquals(self::ROUTE_ROOT.'/testroute/noroute/child', $iterator->key());
+        $this->assertEquals('json', $iterator->current()->getDefault('_format'));
 
-        $route = $routes->get(self::ROUTE_ROOT);
-        $this->assertNotNull($route);
-        $this->assertNull($route->getDefault('_format'));
+        $iterator->next();
+        $this->assertTrue($iterator->valid());
+        $this->assertEquals(self::ROUTE_ROOT.'/testroute', $iterator->key());
+        $this->assertEquals('html', $iterator->current()->getDefault('_format'));
+
+        $iterator->next();
+        $this->assertTrue($iterator->valid());
+        $this->assertEquals(self::ROUTE_ROOT, $iterator->key());
+        $this->assertNull($iterator->current()->getDefault('_format'));
     }
 
     public function testGetRouteCollectionForRequestFormat()
@@ -87,17 +91,21 @@ class RouteProviderTest extends BaseTestCase
         $this->assertCount(3, $routes);
         $this->assertContainsOnlyInstancesOf(RouteObjectInterface::class, $routes);
 
-        $route = $routes->get(self::ROUTE_ROOT.'/testroute/noroute/child');
-        $this->assertNotNull($route);
-        $this->assertEquals('json', $route->getDefault('_format'));
+        $iterator = $routes->getIterator();
 
-        $route = $routes->get(self::ROUTE_ROOT.'/testroute');
-        $this->assertNotNull($route);
-        $this->assertEquals('html', $route->getDefault('_format'));
+        $this->assertTrue($iterator->valid());
+        $this->assertEquals(self::ROUTE_ROOT.'/testroute/noroute/child', $iterator->key());
+        $this->assertEquals('json', $iterator->current()->getDefault('_format'));
 
-        $route = $routes->get(self::ROUTE_ROOT);
-        $this->assertNotNull($route);
-        $this->assertNull($route->getDefault('_format'));
+        $iterator->next();
+        $this->assertTrue($iterator->valid());
+        $this->assertEquals(self::ROUTE_ROOT.'/testroute', $iterator->key());
+        $this->assertEquals('html', $iterator->current()->getDefault('_format'));
+
+        $iterator->next();
+        $this->assertTrue($iterator->valid());
+        $this->assertEquals(self::ROUTE_ROOT, $iterator->key());
+        $this->assertNull($iterator->current()->getDefault('_format'));
     }
 
     /**
@@ -105,11 +113,14 @@ class RouteProviderTest extends BaseTestCase
      */
     public function testGetRouteCollectionForRequestNonPhpcrUrl()
     {
-        $collection = $this->repository->getRouteCollectionForRequest(Request::create('http:///'));
-        $this->assertInstanceOf(RouteCollection::class, $collection);
-        $this->assertCount(1, $collection);
+        $routes = $this->repository->getRouteCollectionForRequest(Request::create('http:///'));
+        $this->assertInstanceOf(RouteCollection::class, $routes);
+        $this->assertCount(1, $routes);
 
-        $this->assertNotNull($collection->get(self::ROUTE_ROOT));
+        $iterator = $routes->getIterator();
+
+        $this->assertTrue($iterator->valid());
+        $this->assertEquals(self::ROUTE_ROOT, $iterator->key());
     }
 
     /**

--- a/tests/Functional/Doctrine/Phpcr/RouteProviderTest.php
+++ b/tests/Functional/Doctrine/Phpcr/RouteProviderTest.php
@@ -66,16 +66,17 @@ class RouteProviderTest extends BaseTestCase
         $this->assertCount(3, $routes);
         $this->assertContainsOnlyInstancesOf(RouteObjectInterface::class, $routes);
 
-        $routes = $routes->all();
-        list($key, $child) = each($routes);
-        $this->assertEquals(self::ROUTE_ROOT.'/testroute/noroute/child', $key);
-        $this->assertEquals('json', $child->getDefault('_format'));
-        list($key, $testroute) = each($routes);
-        $this->assertEquals(self::ROUTE_ROOT.'/testroute', $key);
-        $this->assertEquals('html', $testroute->getDefault('_format'));
-        list($key, $root) = each($routes);
-        $this->assertEquals(self::ROUTE_ROOT, $key);
-        $this->assertNull($root->getDefault('_format'));
+        $route = $routes->get(self::ROUTE_ROOT.'/testroute/noroute/child');
+        $this->assertNotNull($route);
+        $this->assertEquals('json', $route->getDefault('_format'));
+
+        $route = $routes->get(self::ROUTE_ROOT.'/testroute');
+        $this->assertNotNull($route);
+        $this->assertEquals('html', $route->getDefault('_format'));
+
+        $route = $routes->get(self::ROUTE_ROOT);
+        $this->assertNotNull($route);
+        $this->assertNull($route->getDefault('_format'));
     }
 
     public function testGetRouteCollectionForRequestFormat()
@@ -86,16 +87,17 @@ class RouteProviderTest extends BaseTestCase
         $this->assertCount(3, $routes);
         $this->assertContainsOnlyInstancesOf(RouteObjectInterface::class, $routes);
 
-        $routes = $routes->all();
-        list($key, $child) = each($routes);
-        $this->assertEquals(self::ROUTE_ROOT.'/testroute/noroute/child', $key);
-        $this->assertEquals('json', $child->getDefault('_format'));
-        list($key, $testroute) = each($routes);
-        $this->assertEquals(self::ROUTE_ROOT.'/testroute', $key);
-        $this->assertEquals('html', $testroute->getDefault('_format'));
-        list($key, $root) = each($routes);
-        $this->assertEquals(self::ROUTE_ROOT, $key);
-        $this->assertNull($root->getDefault('_format'));
+        $route = $routes->get(self::ROUTE_ROOT.'/testroute/noroute/child');
+        $this->assertNotNull($route);
+        $this->assertEquals('json', $route->getDefault('_format'));
+
+        $route = $routes->get(self::ROUTE_ROOT.'/testroute');
+        $this->assertNotNull($route);
+        $this->assertEquals('html', $route->getDefault('_format'));
+
+        $route = $routes->get(self::ROUTE_ROOT);
+        $this->assertNotNull($route);
+        $this->assertNull($route->getDefault('_format'));
     }
 
     /**
@@ -106,9 +108,8 @@ class RouteProviderTest extends BaseTestCase
         $collection = $this->repository->getRouteCollectionForRequest(Request::create('http:///'));
         $this->assertInstanceOf(RouteCollection::class, $collection);
         $this->assertCount(1, $collection);
-        $routes = $collection->all();
-        list($key, $route) = each($routes);
-        $this->assertEquals(self::ROUTE_ROOT, $key);
+
+        $this->assertNotNull($collection->get(self::ROUTE_ROOT));
     }
 
     /**

--- a/tests/Functional/Routing/DynamicRouterTest.php
+++ b/tests/Functional/Routing/DynamicRouterTest.php
@@ -33,6 +33,7 @@ class DynamicRouterTest extends BaseTestCase
      * @var ChainRouter
      */
     protected $router;
+
     protected $routeNamePrefix;
 
     const ROUTE_ROOT = '/test/routing';

--- a/tests/Unit/DependencyInjection/XmlSchemaTest.php
+++ b/tests/Unit/DependencyInjection/XmlSchemaTest.php
@@ -16,6 +16,7 @@ use Symfony\Cmf\Component\Testing\Unit\XmlSchemaTestCase;
 class XmlSchemaTest extends XmlSchemaTestCase
 {
     protected $fixturesPath;
+
     protected $schemaPath;
 
     public function setUp()

--- a/tests/Unit/Doctrine/Orm/ContentRepositoryTest.php
+++ b/tests/Unit/Doctrine/Orm/ContentRepositoryTest.php
@@ -19,8 +19,11 @@ use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\ContentRepository;
 class ContentRepositoryTest extends \PHPUnit_Framework_TestCase
 {
     private $document;
+
     private $managerRegistry;
+
     private $objectManager;
+
     private $objectRepository;
 
     public function setUp()

--- a/tests/Unit/Doctrine/Phpcr/ContentRepositoryTest.php
+++ b/tests/Unit/Doctrine/Phpcr/ContentRepositoryTest.php
@@ -20,9 +20,13 @@ use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\ContentRepository;
 class ContentRepositoryTest extends \PHPUnit_Framework_TestCase
 {
     private $document;
+
     private $document2;
+
     private $objectManager;
+
     private $objectManager2;
+
     private $managerRegistry;
 
     public function setUp()

--- a/tests/Unit/Doctrine/Phpcr/RouteProviderTest.php
+++ b/tests/Unit/Doctrine/Phpcr/RouteProviderTest.php
@@ -41,6 +41,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
      * @var DocumentManager|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $dmMock;
+
     /**
      * @var DocumentManager|\PHPUnit_Framework_MockObject_MockObject
      */
@@ -50,6 +51,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
      * @var Route|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $routeMock;
+
     /**
      * @var Route|\PHPUnit_Framework_MockObject_MockObject
      */

--- a/tests/Unit/Doctrine/Phpcr/RouteTest.php
+++ b/tests/Unit/Doctrine/Phpcr/RouteTest.php
@@ -17,6 +17,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
 {
     /** @var Route */
     private $route;
+
     private $childRoute1;
 
     public function setUp()

--- a/tests/Unit/Routing/DynamicRouterTest.php
+++ b/tests/Unit/Routing/DynamicRouterTest.php
@@ -26,18 +26,25 @@ use Symfony\Component\Routing\RequestContext;
 class DynamicRouterTest extends \PHPUnit_Framework_TestCase
 {
     protected $matcher;
+
     protected $generator;
+
     /** @var DynamicRouter */
     protected $router;
+
     protected $context;
+
     /** @var Request */
     protected $request;
+
     /**
      * @var RequestStack
      */
     private $requestStack;
+
     /** @var EventDispatcherInterface */
     protected $eventDispatcher;
+
     protected $container;
 
     public function setUp()

--- a/tests/Unit/Validator/Constraints/RouteDefaultsValidatorTest.php
+++ b/tests/Unit/Validator/Constraints/RouteDefaultsValidatorTest.php
@@ -31,6 +31,7 @@ if (!class_exists(ConstraintValidatorTestCase::class)) {
 abstract class RouteDefaultsValidatorTest extends HackBaseClass
 {
     protected $controllerResolver;
+
     protected $engine;
 
     public function testCorrectControllerPath()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This PR updates the tests by removing the usage of the deprecated `each` function.
