### PR TITLE
Fixed #413: Made PHPCR documents validation optional

### DIFF
--- a/src/DependencyInjection/Compiler/ValidationPass.php
+++ b/src/DependencyInjection/Compiler/ValidationPass.php
@@ -21,7 +21,7 @@ class ValidationPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasParameter('cmf_routing.backend_type_phpcr')) {
+        if ($container->hasParameter('cmf_routing.backend_type_phpcr' && $container->hasDefinition('validator.builder'))) {
             $container
                 ->getDefinition('validator.builder')
                 ->addMethodCall('addXmlMappings', [[__DIR__.'/../../Resources/config/validation-phpcr.xml']]);


### PR DESCRIPTION
This validation is done only when the Symfony validator builder is available.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #413
| License       | MIT
| Doc PR        | n/a
