### PR TITLE
Fixed typo introduced in #414

### DIFF
--- a/src/DependencyInjection/Compiler/ValidationPass.php
+++ b/src/DependencyInjection/Compiler/ValidationPass.php
@@ -21,7 +21,7 @@ class ValidationPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasParameter('cmf_routing.backend_type_phpcr' && $container->hasDefinition('validator.builder'))) {
+        if ($container->hasParameter('cmf_routing.backend_type_phpcr') && $container->hasDefinition('validator.builder')) {
             $container
                 ->getDefinition('validator.builder')
                 ->addMethodCall('addXmlMappings', [[__DIR__.'/../../Resources/config/validation-phpcr.xml']]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The tests didn't caught this typo, see #415.

This commit must be merged in the branches which received the PR #414.
Sorry for the inconvenience.

