### PR TITLE
Add compiler passes unit tests

### DIFF
--- a/tests/Unit/DependencyInjection/Compiler/TemplatingValidatorPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/TemplatingValidatorPassTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Cmf\Bundle\RoutingBundle\DependencyInjection\Compiler\TemplatingValidatorPass;
+use Symfony\Cmf\Bundle\RoutingBundle\Validator\Constraints\RouteDefaultsTemplatingValidator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class TemplatingValidatorPassTest extends AbstractCompilerPassTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->registerValidatorService();
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new TemplatingValidatorPass());
+    }
+
+    /**
+     * It should replace the validator class with the templating one and
+     * provide the _templating_ service as second argument.
+     */
+    public function testReplacesValidator()
+    {
+        $this->registerService('templating', \stdClass::class);
+
+        $this->compile();
+
+        $definition = $this->container->getDefinition('cmf_routing.validator.route_defaults');
+
+        $this->assertEquals(RouteDefaultsTemplatingValidator::class, $definition->getClass());
+        $this->assertEquals(['foo', new Reference('templating')], $definition->getArguments());
+    }
+
+    /**
+     * It should leave the validator untouched when the _templating_ service
+     * is not available.
+     */
+    public function testDoesNotReplaceValidator()
+    {
+        $this->compile();
+
+        $definition = $this->container->getDefinition('cmf_routing.validator.route_defaults');
+
+        $this->assertEquals(\stdClass::class, $definition->getClass());
+        $this->assertEquals(['foo', 'bar'], $definition->getArguments());
+    }
+
+    private function registerValidatorService()
+    {
+        $definition = $this->registerService('cmf_routing.validator.route_defaults', \stdClass::class);
+
+        $definition->setArguments(['foo', 'bar']);
+    }
+}

--- a/tests/Unit/DependencyInjection/Compiler/ValidationPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/ValidationPassTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\RoutingBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Cmf\Bundle\RoutingBundle\DependencyInjection\Compiler\ValidationPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ValidationPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new ValidationPass());
+    }
+
+    /**
+     * It should register the PHPCR documents for validation only when:
+     *  - the PHP backend is enabled AND
+     *  - the validator service is available.
+     *
+     * @dataProvider provideDocumentsValidationContext
+     */
+    public function testRegisterDocumentsValidation($hasPhpcr, $hasValidator, $shouldBeRegistered)
+    {
+        if ($hasPhpcr) {
+            $this->setParameter('cmf_routing.backend_type_phpcr', null);
+        }
+
+        if ($hasValidator) {
+            $this->registerService('validator.builder', \stdClass::class);
+        }
+
+        $this->compile();
+
+        if ($shouldBeRegistered) {
+            $r = new \ReflectionClass(ValidationPass::class);
+            $dir = \dirname($r->getFilename());
+
+            $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+                'validator.builder',
+                'addXmlMappings',
+                [["{$dir}/../../Resources/config/validation-phpcr.xml"]]
+            );
+        } else {
+            if ($hasValidator) {
+                $definition = $this->container->findDefinition('validator.builder');
+
+                $this->assertFalse($definition->hasMethodCall('addXmlMappings'));
+            }
+        }
+    }
+
+    /**
+     * Provides the contexts in witch the documents validation registering occurs.
+     *
+     * A context is:
+     *
+     *  `[$hasPhpcr, $hasValidator, $shouldBeRegistered]`
+     *
+     * where:
+     *  - _$hasPhpcr: Is the PHPCR backend enabled ?
+     *  - _$hasValidator: Is the validator available ?
+     *  - _$shouldBeRegistered_: Should the documents validation be registered ?
+     */
+    public function provideDocumentsValidationContext()
+    {
+        return [
+            [true, true, true],
+            [true, false, false],
+            [false, true, false],
+            [false, false, false],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #415 
| License       | MIT
| Doc PR        | n/a

This PR adds unit tests for the _ValidationPass_ and the _TemplatingValidationPass_ compiler passes.