### PR TITLE
use twig/twig instead of symfony/twig-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1",
         "symfony-cmf/routing": "^2.0",
         "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",
-        "twig/twig": "^1.35|^2.4.4"
+        "twig/twig": "^1.35 || ^2.4.4"
     },
     "require-dev": {
         "doctrine/phpcr-odm": "^1.4|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1",
         "symfony-cmf/routing": "^2.0",
         "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",
-        "symfony/twig-bundle": "^2.8 || ^3.3 || ^4.0"
+        "twig/twig": "^1.35|^2.4.4"
     },
     "require-dev": {
         "doctrine/phpcr-odm": "^1.4|^2.0",


### PR DESCRIPTION
I realized in https://github.com/symfony-cmf/symfony-cmf/pull/258 that `symfony/twig-bundle` isn't the correct choice. So i try `twig/twig`