### PR TITLE
Add another invalid character

### DIFF
--- a/src/Doctrine/Phpcr/RouteProvider.php
+++ b/src/Doctrine/Phpcr/RouteProvider.php
@@ -64,7 +64,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
      */
     public function getCandidates(Request $request)
     {
-        $invalidCharacters = [':', '[', ']'];
+        $invalidCharacters = [':', '[', ']', '|'];
         foreach ($invalidCharacters as $invalidCharacter) {
             if (false !== strpos($request->getPathInfo(), $invalidCharacter)) {
                 return [];


### PR DESCRIPTION
As it turns out, the pipe character also causes Jackrabbit errors.

| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | /no
| Fixed tickets | #430
| License       | MIT
| Doc PR        | reference to the documentation PR, if any
