### PR TITLE
Add another invalid character

### DIFF
--- a/src/Doctrine/Phpcr/RouteProvider.php
+++ b/src/Doctrine/Phpcr/RouteProvider.php
@@ -64,7 +64,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
      */
     public function getCandidates(Request $request)
     {
-        $invalidCharacters = [':', '[', ']', '|'];
+        $invalidCharacters = [':', '[', ']', '|', '*'];
         foreach ($invalidCharacters as $invalidCharacter) {
             if (false !== strpos($request->getPathInfo(), $invalidCharacter)) {
                 return [];


### PR DESCRIPTION
This time I went through and tried every "special" character I think of, including emojis, and the asterisk is the only one that caused a Jackrabbit error.

| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | /no
| Fixed tickets | #430
| License       | MIT
| Doc PR        | reference to the documentation PR, if any
