### PR TITLE
fix symfony 4.3 deprecation about root nodes

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -33,8 +33,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $root = $treeBuilder->root('cmf_routing');
+        $treeBuilder = new TreeBuilder('cmf_routing');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $root = $treeBuilder->root('cmf_routing');
+        }
 
         $this->addChainSection($root);
         $this->addDynamicSection($root);


### PR DESCRIPTION
`The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "cmf_routing" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.`


| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / the branch of the current release for fixes
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 
