### PR TITLE
Add service alias for the ChainRouterInterface

### DIFF
--- a/src/Resources/config/routing-chain.xml
+++ b/src/Resources/config/routing-chain.xml
@@ -11,5 +11,6 @@
                 <argument type="service" id="router.request_context" />
             </call>
         </service>
+        <service id="Symfony\Cmf\Component\Routing\ChainRouterInterface" alias='cmf_routing.router'/>
     </services>
 </container>


### PR DESCRIPTION
Alias `Symfony\Cmf\Component\Routing\ChainRouterInterface` to `cmf_routing.router` to allow autowiring in strict mode.
Not sure if this is the correct target branch, please check.

| Q             | A
| ------------- | ---
| Branch?       | 2.1? Not sure.
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT
| Doc PR        | reference to the documentation PR, if any