### PR TITLE
Avoid using deprecated feature from symfony-cmf/routing library

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -14,7 +14,6 @@ jobs:
         name: 'PHP ${{ matrix.php-version }}, Symfony ${{ matrix.symfony-version }} ${{ matrix.dependencies}}'
         runs-on: ubuntu-20.04
         env:
-            SYMFONY_PHPUNIT_VERSION: 8
             SYMFONY_DEPRECATIONS_HELPER: weak
             SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
@@ -27,7 +26,7 @@ jobs:
                     - php-version: '7.4'
                       symfony-version: '^4.4'
                     - php-version: '7.4'
-                      symfony-version: '5.0.*'
+                      symfony-version: '^5.4'
                     - php-version: '8.0'
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "symfony-cmf/routing": "^2.3.0",
+        "symfony-cmf/routing": "^2.3.2",
         "symfony/framework-bundle": "^4.4 || ^5.0"
     },
     "require-dev": {

--- a/src/Controller/RedirectController.php
+++ b/src/Controller/RedirectController.php
@@ -12,6 +12,7 @@
 namespace Symfony\Cmf\Bundle\RoutingBundle\Controller;
 
 use Symfony\Cmf\Component\Routing\RedirectRouteInterface;
+use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -52,7 +53,7 @@ class RedirectController
         if (empty($url)) {
             $routeTarget = $contentDocument->getRouteTarget();
             if ($routeTarget) {
-                $url = $this->router->generate($routeTarget, $contentDocument->getParameters(), UrlGeneratorInterface::ABSOLUTE_URL);
+                $url = $this->router->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, array_merge($contentDocument->getParameters(), [RouteObjectInterface::ROUTE_OBJECT => $routeTarget]), UrlGeneratorInterface::ABSOLUTE_URL);
             } else {
                 $routeName = $contentDocument->getRouteName();
                 $url = $this->router->generate($routeName, $contentDocument->getParameters(), UrlGeneratorInterface::ABSOLUTE_URL);

--- a/tests/Functional/Routing/DynamicRouterTest.php
+++ b/tests/Functional/Routing/DynamicRouterTest.php
@@ -339,14 +339,14 @@ class DynamicRouterTest extends BaseTestCase
     {
         $route = $this->getDm()->find(null, self::ROUTE_ROOT.'/testroute/child');
 
-        $url = $this->router->generate($route, ['test' => 'value']);
+        $url = $this->router->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, ['test' => 'value', RouteObjectInterface::ROUTE_OBJECT => $route]);
         $this->assertEquals('/testroute/child?test=value', $url);
     }
 
     public function testGenerateAbsolute()
     {
         $route = $this->getDm()->find(null, self::ROUTE_ROOT.'/testroute/child');
-        $url = $this->router->generate($route, ['test' => 'value'], UrlGeneratorInterface::ABSOLUTE_URL);
+        $url = $this->router->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, ['test' => 'value', RouteObjectInterface::ROUTE_OBJECT => $route], UrlGeneratorInterface::ABSOLUTE_URL);
         $this->assertEquals('http://localhost/testroute/child?test=value', $url);
     }
 
@@ -354,7 +354,7 @@ class DynamicRouterTest extends BaseTestCase
     {
         $route = $this->getDm()->find(null, self::ROUTE_ROOT.'/testroute');
 
-        $url = $this->router->generate($route, ['slug' => 'gen-slug', 'test' => 'value']);
+        $url = $this->router->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, ['slug' => 'gen-slug', 'test' => 'value', RouteObjectInterface::ROUTE_OBJECT => $route]);
         $this->assertEquals('/testroute/gen-slug?test=value', $url);
     }
 
@@ -363,14 +363,14 @@ class DynamicRouterTest extends BaseTestCase
         $route = $this->getDm()->find(null, self::ROUTE_ROOT.'/testroute');
 
         $this->expectException(InvalidParameterException::class);
-        $this->router->generate($route, ['slug' => 'gen-slug', 'id' => 'nonumber']);
+        $this->router->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, ['slug' => 'gen-slug', 'id' => 'nonumber', RouteObjectInterface::ROUTE_OBJECT => $route]);
     }
 
     public function testGenerateDefaultFormat()
     {
         $route = $this->getDm()->find(null, self::ROUTE_ROOT.'/format');
 
-        $url = $this->router->generate($route, ['id' => 37]);
+        $url = $this->router->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, ['id' => 37, RouteObjectInterface::ROUTE_OBJECT => $route]);
         $this->assertEquals('/format/37', $url);
     }
 
@@ -378,7 +378,7 @@ class DynamicRouterTest extends BaseTestCase
     {
         $route = $this->getDm()->find(null, self::ROUTE_ROOT.'/format');
 
-        $url = $this->router->generate($route, ['id' => 37, '_format' => 'json']);
+        $url = $this->router->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, ['id' => 37, '_format' => 'json', RouteObjectInterface::ROUTE_OBJECT => $route]);
         $this->assertEquals('/format/37.json', $url);
     }
 
@@ -387,6 +387,6 @@ class DynamicRouterTest extends BaseTestCase
         $route = $this->getDm()->find(null, self::ROUTE_ROOT.'/format');
 
         $this->expectException(InvalidParameterException::class);
-        $this->router->generate($route, ['id' => 37, '_format' => 'xyz']);
+        $this->router->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, ['id' => 37, '_format' => 'xyz', RouteObjectInterface::ROUTE_OBJECT => $route]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Passing objects as the route name is deprecated in `symfony-cmf/routing`, so I refactored this controller that there are no deprecations triggered.

The 2 fixes in the github workflow are needed to make the tests pass (the failures are unrelated to this change)