### PR TITLE
Symfony 6.0 compatibility

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -22,13 +22,14 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: '7.4'
+                    - php-version: '8.0'
                       dependencies: 'lowest'
-                    - php-version: '7.4'
-                      symfony-version: '^4.4'
-                    - php-version: '7.4'
+                    - php-version: '8.0'
                       symfony-version: '5.0.*'
                     - php-version: '8.0'
+                      symfony-version: '6.0.*'
+                    - php-version: '8.1'
+                      symfony-version: '6.0.*'
 
         steps:
             - name: Checkout project

--- a/composer.json
+++ b/composer.json
@@ -15,28 +15,28 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "symfony-cmf/routing": "^2.3.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0"
+        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "jackalope/jackalope-doctrine-dbal": "^1.3",
         "doctrine/phpcr-odm": "^1.4|^2.0",
-        "symfony/phpunit-bridge": "^5.0",
+        "symfony/phpunit-bridge": "^5.0 || ^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1.0",
         "matthiasnoback/symfony-config-test": "^4.1.0",
         "doctrine/orm": "^2.5",
         "symfony-cmf/testing": "^4.0",
         "doctrine/data-fixtures": "^1.0.0",
-        "symfony/form": "^4.4 || ^5.0",
-        "symfony/translation": "^4.4 || ^5.0",
-        "symfony/validator": "^4.4 || ^5.0",
-        "symfony/security-bundle": "^4.4 || ^5.0",
+        "symfony/form": "^4.4 || ^5.0 || ^6.0",
+        "symfony/translation": "^4.4 || ^5.0 || ^6.0",
+        "symfony/validator": "^4.4 || ^5.0 || ^6.0",
+        "symfony/security-bundle": "^4.4 || ^5.0 || ^6.0",
         "doctrine/doctrine-bundle": "^2.0",
-        "symfony/twig-bundle": "^4.4 || ^5.0",
+        "symfony/twig-bundle": "^4.4 || ^5.0 || ^6.0",
         "symfony/monolog-bundle": "^3.5",
         "doctrine/phpcr-bundle": "^2.3",
-        "symfony/serializer": "^4.4 || ^5.0",
+        "symfony/serializer": "^4.4 || ^5.0 || ^6.0",
         "twig/twig": "^2.4.4 || ^3.0"
     },
     "suggest": {

--- a/src/CmfRoutingBundle.php
+++ b/src/CmfRoutingBundle.php
@@ -122,7 +122,7 @@ class CmfRoutingBundle extends Bundle
      *
      * @return CompilerPassInterface
      */
-    private function buildBaseCompilerPass($compilerClass, $driverClass, $type)
+    private function buildBaseCompilerPass($compilerClass, $driverClass, $type): CompilerPassInterface
     {
         $arguments = [[realpath(__DIR__.'/Resources/config/doctrine-base')], sprintf('.%s.xml', $type)];
         $locator = new Definition(DefaultFileLocator::class, $arguments);

--- a/src/Controller/RedirectController.php
+++ b/src/Controller/RedirectController.php
@@ -45,7 +45,7 @@ class RedirectController
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse the response
      */
-    public function redirectAction(RedirectRouteInterface $contentDocument)
+    public function redirectAction(RedirectRouteInterface $contentDocument): \Symfony\Component\HttpFoundation\RedirectResponse
     {
         $url = $contentDocument->getUri();
 

--- a/src/DependencyInjection/CmfRoutingExtension.php
+++ b/src/DependencyInjection/CmfRoutingExtension.php
@@ -280,12 +280,12 @@ class CmfRoutingExtension extends Extension
      *
      * @return string The XSD base path
      */
-    public function getXsdValidationBasePath()
+    public function getXsdValidationBasePath(): string
     {
         return __DIR__.'/../Resources/config/schema';
     }
 
-    public function getNamespace()
+    public function getNamespace(): string
     {
         return 'http://cmf.symfony.com/schema/dic/routing';
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ class Configuration implements ConfigurationInterface
      *
      * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('cmf_routing');
         if (method_exists($treeBuilder, 'getRootNode')) {

--- a/src/Doctrine/DoctrineProvider.php
+++ b/src/Doctrine/DoctrineProvider.php
@@ -28,12 +28,12 @@ abstract class DoctrineProvider
      *
      * @var string|null Name of object manager to use
      */
-    protected $managerName;
+    protected ?string $managerName;
 
     /**
      * @var ManagerRegistry
      */
-    protected $managerRegistry;
+    protected ManagerRegistry $managerRegistry;
 
     /**
      * Class name of the object class to find, null for PHPCR-ODM as it can
@@ -41,14 +41,14 @@ abstract class DoctrineProvider
      *
      * @var string|null
      */
-    protected $className;
+    protected ?string $className;
 
     /**
      * Limit to apply when calling getRoutesByNames() with null.
      *
      * @var int|null
      */
-    protected $routeCollectionLimit;
+    protected ?int $routeCollectionLimit;
 
     /**
      * @param string $className
@@ -87,7 +87,7 @@ abstract class DoctrineProvider
      *
      * @return ObjectManager
      */
-    protected function getObjectManager()
+    protected function getObjectManager(): ObjectManager
     {
         return $this->managerRegistry->getManager($this->managerName);
     }

--- a/src/Doctrine/Orm/ContentRepository.php
+++ b/src/Doctrine/Orm/ContentRepository.php
@@ -33,7 +33,7 @@ class ContentRepository extends DoctrineProvider implements ContentRepositoryInt
      *
      * @return array with model first element, id second
      */
-    protected function getModelAndId($identifier)
+    protected function getModelAndId($identifier): array
     {
         return explode(':', $identifier, 2);
     }
@@ -43,7 +43,7 @@ class ContentRepository extends DoctrineProvider implements ContentRepositoryInt
      *
      * @param string $id The ID contains both model name and id, separated by a colon
      */
-    public function findById($id)
+    public function findById($id): object
     {
         list($model, $modelId) = $this->getModelAndId($id);
 
@@ -53,10 +53,10 @@ class ContentRepository extends DoctrineProvider implements ContentRepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function getContentId($content)
+    public function getContentId($content): ?string
     {
         if (!\is_object($content)) {
-            return;
+            return null;
         }
 
         try {
@@ -69,7 +69,7 @@ class ContentRepository extends DoctrineProvider implements ContentRepositoryInt
 
             return implode(':', [$class, reset($ids)]);
         } catch (\Exception $e) {
-            return;
+            return null;
         }
     }
 }

--- a/src/Doctrine/Orm/RedirectRoute.php
+++ b/src/Doctrine/Orm/RedirectRoute.php
@@ -68,7 +68,7 @@ class RedirectRoute extends RedirectRouteModel
     /**
      * {@inheritdoc}
      */
-    public function getParameters()
+    public function getParameters(): array
     {
         $params = json_decode($this->serialisedParameters);
 
@@ -78,7 +78,7 @@ class RedirectRoute extends RedirectRouteModel
     /**
      * {@inheritdoc}
      */
-    public function getPath()
+    public function getPath(): string
     {
         $pattern = parent::getPath();
         if ($this->getOption('add_trailing_slash') && '/' !== $pattern[\strlen($pattern) - 1]) {
@@ -91,7 +91,7 @@ class RedirectRoute extends RedirectRouteModel
     /**
      * {@inheritdoc}
      */
-    protected function isBooleanOption($name)
+    protected function isBooleanOption($name): bool
     {
         return 'add_trailing_slash' === $name || parent::isBooleanOption($name);
     }

--- a/src/Doctrine/Orm/Route.php
+++ b/src/Doctrine/Orm/Route.php
@@ -35,7 +35,7 @@ class Route extends RouteModel
      *
      * @return self
      */
-    public function setName($name)
+    public function setName($name): \Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route
     {
         $this->name = $name;
 
@@ -47,7 +47,7 @@ class Route extends RouteModel
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -59,7 +59,7 @@ class Route extends RouteModel
      *
      * @return self
      */
-    public function setPosition($position)
+    public function setPosition($position): \Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route
     {
         $this->position = $position;
 
@@ -71,7 +71,7 @@ class Route extends RouteModel
      *
      * @return int
      */
-    public function getPosition()
+    public function getPosition(): int
     {
         return $this->position;
     }

--- a/src/Doctrine/Orm/RouteProvider.php
+++ b/src/Doctrine/Orm/RouteProvider.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm;
 
+use Symfony\Component\Routing\Route as SymfonyRoute;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectRepository;
@@ -35,7 +36,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
     /**
      * @var CandidatesInterface
      */
-    private $candidatesStrategy;
+    private CandidatesInterface $candidatesStrategy;
 
     public function __construct(ManagerRegistry $managerRegistry, CandidatesInterface $candidatesStrategy, $className)
     {
@@ -46,7 +47,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getRouteCollectionForRequest(Request $request)
+    public function getRouteCollectionForRequest(Request $request): RouteCollection
     {
         $collection = new RouteCollection();
 
@@ -66,7 +67,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getRouteByName($name)
+    public function getRouteByName($name): SymfonyRoute
     {
         if (!$this->candidatesStrategy->isCandidate($name)) {
             throw new RouteNotFoundException(sprintf('Route "%s" is not handled by this route provider', $name));
@@ -83,7 +84,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getRoutesByNames($names = null)
+    public function getRoutesByNames($names = null): array
     {
         if (null === $names) {
             if (0 === $this->routeCollectionLimit) {
@@ -113,7 +114,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
     /**
      * @return ObjectRepository
      */
-    protected function getRouteRepository()
+    protected function getRouteRepository(): ObjectRepository
     {
         return $this->getObjectManager()->getRepository($this->className);
     }

--- a/src/Doctrine/Phpcr/ContentRepository.php
+++ b/src/Doctrine/Phpcr/ContentRepository.php
@@ -28,7 +28,7 @@ class ContentRepository extends DoctrineProvider implements ContentRepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function findById($id)
+    public function findById($id): object
     {
         return $this->getObjectManager()->find(null, $id);
     }
@@ -36,16 +36,16 @@ class ContentRepository extends DoctrineProvider implements ContentRepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function getContentId($content)
+    public function getContentId($content): ?string
     {
         if (!\is_object($content)) {
-            return;
+            return null;
         }
 
         try {
             return $this->getObjectManager()->getUnitOfWork()->getDocumentId($content);
         } catch (\Exception $e) {
-            return;
+            return null;
         }
     }
 }

--- a/src/Doctrine/Phpcr/IdPrefixListener.php
+++ b/src/Doctrine/Phpcr/IdPrefixListener.php
@@ -44,7 +44,7 @@ class IdPrefixListener
     /**
      * @return array
      */
-    protected function getPrefixes()
+    protected function getPrefixes(): array
     {
         return $this->candidates->getPrefixes();
     }

--- a/src/Doctrine/Phpcr/LocaleListener.php
+++ b/src/Doctrine/Phpcr/LocaleListener.php
@@ -148,7 +148,7 @@ class LocaleListener
     /**
      * @return array
      */
-    protected function getPrefixes()
+    protected function getPrefixes(): array
     {
         return $this->candidates->getPrefixes();
     }

--- a/src/Doctrine/Phpcr/PrefixCandidates.php
+++ b/src/Doctrine/Phpcr/PrefixCandidates.php
@@ -65,7 +65,7 @@ class PrefixCandidates extends Candidates
      *
      * A name is a candidate if it starts with one of the prefixes
      */
-    public function isCandidate($name)
+    public function isCandidate($name): bool
     {
         foreach ($this->getPrefixes() as $prefix) {
             // $name is the route document path
@@ -100,7 +100,7 @@ class PrefixCandidates extends Candidates
     /**
      * {@inheritdoc}
      */
-    public function getCandidates(Request $request)
+    public function getCandidates(Request $request): array
     {
         $candidates = [];
         $url = rawurldecode($request->getPathInfo());
@@ -151,7 +151,7 @@ class PrefixCandidates extends Candidates
      *
      * @return array The prefixes
      */
-    public function getPrefixes()
+    public function getPrefixes(): array
     {
         return $this->idPrefixes;
     }
@@ -171,7 +171,7 @@ class PrefixCandidates extends Candidates
      *
      * @return bool
      */
-    protected function isCandidateValid($candidate)
+    protected function isCandidateValid($candidate): bool
     {
         // Candidates cannot start or end with a space in Jackrabbit.
         if (' ' === substr($candidate, 0, 1) || ' ' === substr($candidate, -1)) {
@@ -199,7 +199,7 @@ class PrefixCandidates extends Candidates
      *
      * For example the CmfSimpleCmsBundle Page documents.
      */
-    protected function determineLocale($url)
+    protected function determineLocale($url): string|bool
     {
         $locale = parent::determineLocale($url);
         if ($locale && $this->doctrine) {
@@ -212,7 +212,7 @@ class PrefixCandidates extends Candidates
     /**
      * @return DocumentManager The document manager
      */
-    protected function getDocumentManager()
+    protected function getDocumentManager(): DocumentManager
     {
         return $this->doctrine->getManager($this->managerName);
     }

--- a/src/Doctrine/Phpcr/PrefixInterface.php
+++ b/src/Doctrine/Phpcr/PrefixInterface.php
@@ -22,11 +22,11 @@ interface PrefixInterface
     /**
      * @return string the full path of this document in the repository
      */
-    public function getId();
+    public function getId(): string;
 
     /**
      * @param string $prefix The path in the repository to the routing root
      *                       document
      */
-    public function setPrefix($prefix);
+    public function setPrefix(string $prefix): self;
 }

--- a/src/Doctrine/Phpcr/RedirectRoute.php
+++ b/src/Doctrine/Phpcr/RedirectRoute.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr;
 
+use Symfony\Cmf\Bundle\RoutingBundle\Model\Route as SymfonyRoute;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\PHPCR\HierarchyInterface;
 use Symfony\Cmf\Bundle\RoutingBundle\Model\RedirectRoute as RedirectRouteModel;
@@ -77,7 +78,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      *
      * @return $this
      */
-    public function setParentDocument($parent)
+    public function setParentDocument($parent): self
     {
         $this->parent = $parent;
 
@@ -87,7 +88,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
     /**
      * {@inheritdoc}
      */
-    public function getParentDocument()
+    public function getParentDocument(): ?object
     {
         return $this->parent;
     }
@@ -96,7 +97,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      * @deprecated For BC with the PHPCR-ODM 1.4 HierarchyInterface
      * @see setParentDocument
      */
-    public function setParent($parent)
+    public function setParent($parent): self
     {
         @trigger_error('The '.__METHOD__.'() method is deprecated and will be removed in version 3.0. Use setParentDocument() instead.', \E_USER_DEPRECATED);
 
@@ -107,7 +108,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      * @deprecated For BC with the PHPCR-ODM 1.4 HierarchyInterface
      * @see getParentDocument
      */
-    public function getParent()
+    public function getParent(): ?object
     {
         @trigger_error('The '.__METHOD__.'() method is deprecated and will be removed in version 3.0. Use getParentDocument() instead.', \E_USER_DEPRECATED);
 
@@ -123,7 +124,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      *
      * @return self
      */
-    public function setName($name)
+    public function setName($name): \Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute
     {
         $this->name = $name;
 
@@ -145,7 +146,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      *
      * @return self
      */
-    public function setPosition($parent, $name)
+    public function setPosition($parent, $name): \Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute
     {
         $this->parent = $parent;
         $this->name = $name;
@@ -160,7 +161,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): self
     {
         $this->id = $id;
 
@@ -172,12 +173,14 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      *
      * Overwritten to translate into a move operation.
      */
-    public function setStaticPrefix($prefix)
+    public function setStaticPrefix($prefix): SymfonyRoute
     {
         $this->id = str_replace($this->getStaticPrefix(), $prefix, $this->id);
+
+        return $this;
     }
 
-    public function getPrefix()
+    public function getPrefix(): string
     {
         return $this->idPrefix;
     }
@@ -185,9 +188,9 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
     /**
      * {@inheritdoc}
      */
-    public function setPrefix($idPrefix)
+    public function setPrefix(string $prefix): PrefixInterface
     {
-        $this->idPrefix = $idPrefix;
+        $this->idPrefix = $prefix;
 
         return $this;
     }
@@ -197,7 +200,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      *
      * Overwrite model method as we need to build this
      */
-    public function getStaticPrefix()
+    public function getStaticPrefix(): string
     {
         return $this->generateStaticPrefix($this->getId(), $this->idPrefix);
     }
@@ -210,13 +213,13 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      *
      * @throws \LogicException if there is no prefix or the prefix does not match
      */
-    public function generateStaticPrefix($id, $idPrefix)
+    public function generateStaticPrefix(string $id, string $idPrefix): string
     {
         if ('' === $idPrefix) {
             throw new \LogicException('Can not determine the prefix. Either this is a new, unpersisted document or the listener that calls setPrefix is not set up correctly.');
         }
 
-        if (0 !== strpos($id, $idPrefix)) {
+        if (!\str_starts_with($id, $idPrefix)) {
             throw new \LogicException("The id prefix '$idPrefix' does not match the route document path '$id'");
         }
 
@@ -231,7 +234,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
     /**
      * {@inheritdoc}
      */
-    public function getPath()
+    public function getPath(): string
     {
         $pattern = parent::getPath();
         if ($this->getOption('add_trailing_slash') && '/' !== $pattern[\strlen($pattern) - 1]) {
@@ -249,7 +252,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      *
      * @return array - array of RouteObjectInterface's
      */
-    public function getRouteChildren()
+    public function getRouteChildren(): array
     {
         $children = [];
 
@@ -265,7 +268,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
     /**
      * {@inheritdoc}
      */
-    protected function isBooleanOption($name)
+    protected function isBooleanOption($name): bool
     {
         return 'add_trailing_slash' === $name || parent::isBooleanOption($name);
     }

--- a/src/Doctrine/Phpcr/Route.php
+++ b/src/Doctrine/Phpcr/Route.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr;
 
+use Symfony\Cmf\Bundle\RoutingBundle\Model\Route as RouteFIXME;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\PHPCR\Exception\InvalidArgumentException;
@@ -31,21 +32,21 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * @var object
      */
-    protected $parent;
+    protected object $parent;
 
     /**
      * PHPCR node name.
      *
      * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * Child route documents.
      *
      * @var Collection
      */
-    protected $children;
+    protected Collection $children;
 
     /**
      * The part of the PHPCR path that does not belong to the url.
@@ -54,7 +55,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * @var string|null
      */
-    protected $idPrefix;
+    protected ?string $idPrefix;
 
     /**
      * PHPCR id can not end on '/', so we need an additional option for a
@@ -82,7 +83,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * @return $this
      */
-    public function setParentDocument($parent)
+    public function setParentDocument($parent): self
     {
         if (!\is_object($parent)) {
             throw new InvalidArgumentException('Parent must be an object '.\gettype($parent).' given.');
@@ -99,7 +100,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * @return object The parent document
      */
-    public function getParentDocument()
+    public function getParentDocument(): object
     {
         return $this->parent;
     }
@@ -108,7 +109,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      * @deprecated For BC with the PHPCR-ODM 1.4 HierarchyInterface
      * @see setParentDocument
      */
-    public function setParent($parent)
+    public function setParent($parent): self
     {
         @trigger_error('The '.__METHOD__.'() method is deprecated and will be removed in version 3.0. Use setParentDocument() instead.', \E_USER_DEPRECATED);
 
@@ -119,7 +120,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      * @deprecated For BC with the PHPCR-ODM 1.4 HierarchyInterface
      * @see getParentDocument
      */
-    public function getParent()
+    public function getParent(): ?object
     {
         @trigger_error('The '.__METHOD__.'() method is deprecated and will be removed in version 3.0. Use getParentDocument() instead.', \E_USER_DEPRECATED);
 
@@ -135,14 +136,14 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * @return self
      */
-    public function setName($name)
+    public function setName(string $name): self
     {
         $this->name = $name;
 
         return $this;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -157,7 +158,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * @return self
      */
-    public function setPosition($parent, $name)
+    public function setPosition(object $parent, string $name): self
     {
         if (!\is_object($parent)) {
             throw new InvalidArgumentException('Parent must be an object '.\gettype($parent).' given.');
@@ -176,7 +177,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId(string $id): self
     {
         $this->id = $id;
 
@@ -188,12 +189,14 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * Overwritten to translate into a move operation.
      */
-    public function setStaticPrefix($prefix)
+    public function setStaticPrefix(string $prefix): self
     {
         $this->id = str_replace($this->getStaticPrefix(), $prefix, $this->id);
+
+        return $this;
     }
 
-    public function getPrefix()
+    public function getPrefix(): string
     {
         return $this->idPrefix;
     }
@@ -201,9 +204,9 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
     /**
      * {@inheritdoc}
      */
-    public function setPrefix($idPrefix)
+    public function setPrefix(string $prefix): self
     {
-        $this->idPrefix = $idPrefix;
+        $this->idPrefix = $prefix;
 
         return $this;
     }
@@ -213,7 +216,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * Overwrite model method as we need to build this
      */
-    public function getStaticPrefix()
+    public function getStaticPrefix(): string
     {
         $path = $this->getId();
         $prefix = $this->getPrefix();
@@ -229,13 +232,13 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * @throws \LogicException if there is no prefix or the prefix does not match
      */
-    public function generateStaticPrefix($id, $idPrefix)
+    public function generateStaticPrefix(string $id, string $idPrefix): string
     {
         if ('' === $idPrefix || null === $idPrefix) {
             throw new \LogicException('Can not determine the prefix. Either this is a new, unpersisted document or the listener that calls setPrefix is not set up correctly.');
         }
 
-        if (0 !== strpos($id, $idPrefix)) {
+        if (!\str_starts_with($id, $idPrefix)) {
             throw new \LogicException("The id prefix '$idPrefix' does not match the route document path '$id'");
         }
 
@@ -252,7 +255,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * Handle the trailing slash option.
      */
-    public function getPath()
+    public function getPath(): string
     {
         $pattern = parent::getPath();
         if ($this->getOption('add_trailing_slash') && '/' !== $pattern[\strlen($pattern) - 1]) {
@@ -269,7 +272,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * @return RouteObjectInterface[]
      */
-    public function getRouteChildren()
+    public function getRouteChildren(): array
     {
         $children = [];
 
@@ -287,7 +290,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * @return Collection
      */
-    public function getChildren()
+    public function getChildren(): Collection
     {
         return $this->children;
     }
@@ -295,7 +298,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
     /**
      * {@inheritdoc}
      */
-    protected function isBooleanOption($name)
+    protected function isBooleanOption($name): bool
     {
         return 'add_trailing_slash' === $name || parent::isBooleanOption($name);
     }

--- a/src/Doctrine/Phpcr/RouteProvider.php
+++ b/src/Doctrine/Phpcr/RouteProvider.php
@@ -60,7 +60,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
     /**
      * @return array a list of PHPCR-ODM ids
      */
-    public function getCandidates(Request $request)
+    public function getCandidates(Request $request): array
     {
         $invalidCharacters = [':', '[', ']', '|', '*'];
         foreach ($invalidCharacters as $invalidCharacter) {
@@ -80,7 +80,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
      * object, it is filtered out. In the extreme case this can also lead to an
      * empty list being returned.
      */
-    public function getRouteCollectionForRequest(Request $request)
+    public function getRouteCollectionForRequest(Request $request): RouteCollection
     {
         $candidates = $this->getCandidates($request);
 
@@ -114,7 +114,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
      *
      * @param string $name The absolute path or uuid of the Route document
      */
-    public function getRouteByName($name)
+    public function getRouteByName($name): SymfonyRoute
     {
         if (UUIDHelper::isUUID($name)) {
             $route = $this->getObjectManager()->find($this->className, $name);
@@ -152,7 +152,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
      *
      * @return array
      */
-    private function getAllRoutes()
+    private function getAllRoutes(): array
     {
         if (0 === $this->routeCollectionLimit) {
             return [];
@@ -186,7 +186,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getRoutesByNames($names = null)
+    public function getRoutesByNames($names = null): array
     {
         if (null === $names) {
             return $this->getAllRoutes();

--- a/src/Doctrine/RouteConditionMetadataListener.php
+++ b/src/Doctrine/RouteConditionMetadataListener.php
@@ -30,7 +30,7 @@ class RouteConditionMetadataListener implements EventSubscriber
     /**
      * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             'loadClassMetadata',

--- a/src/Form/Type/RouteTypeType.php
+++ b/src/Form/Type/RouteTypeType.php
@@ -50,7 +50,7 @@ class RouteTypeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }
@@ -58,7 +58,7 @@ class RouteTypeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'cmf_routing_route_type';
     }

--- a/src/Model/RedirectRoute.php
+++ b/src/Model/RedirectRoute.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Cmf\Bundle\RoutingBundle\Model;
 
+use \Symfony\Cmf\Bundle\RoutingBundle\Model\Route as Route;
+use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use LogicException;
 use Symfony\Cmf\Component\Routing\RedirectRouteInterface;
 use Symfony\Component\Routing\Route as SymfonyRoute;
@@ -54,7 +56,7 @@ class RedirectRoute extends Route implements RedirectRouteInterface
      *
      * @throws LogicException
      */
-    public function setContent($document)
+    public function setContent($document): Route
     {
         throw new LogicException('Do not set a content for the redirect route. It is its own content.');
     }
@@ -62,7 +64,7 @@ class RedirectRoute extends Route implements RedirectRouteInterface
     /**
      * {@inheritdoc}
      */
-    public function getContent()
+    public function getContent(): ?object
     {
         return $this;
     }
@@ -81,7 +83,7 @@ class RedirectRoute extends Route implements RedirectRouteInterface
     /**
      * {@inheritdoc}
      */
-    public function getRouteTarget()
+    public function getRouteTarget(): RouteObjectInterface
     {
         return $this->routeTarget;
     }
@@ -99,7 +101,7 @@ class RedirectRoute extends Route implements RedirectRouteInterface
     /**
      * {@inheritdoc}
      */
-    public function getRouteName()
+    public function getRouteName(): string
     {
         return $this->routeName;
     }
@@ -118,7 +120,7 @@ class RedirectRoute extends Route implements RedirectRouteInterface
     /**
      * {@inheritdoc}
      */
-    public function isPermanent()
+    public function isPermanent(): bool
     {
         return $this->permanent;
     }
@@ -138,7 +140,7 @@ class RedirectRoute extends Route implements RedirectRouteInterface
     /**
      * {@inheritdoc}
      */
-    public function getParameters()
+    public function getParameters(): array
     {
         return $this->parameters;
     }
@@ -156,7 +158,7 @@ class RedirectRoute extends Route implements RedirectRouteInterface
     /**
      * {@inheritdoc}
      */
-    public function getUri()
+    public function getUri(): string
     {
         return $this->uri;
     }

--- a/src/Model/Route.php
+++ b/src/Model/Route.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\RoutingBundle\Model;
 
+use Symfony\Component\Routing\CompiledRoute;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 use Symfony\Component\Routing\RouteCompiler;
@@ -27,14 +28,14 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * @var string
      */
-    protected $id;
+    protected string $id;
 
     /**
      * The referenced content object.
      *
      * @var object
      */
-    protected $content;
+    protected object $content;
 
     /**
      * Part of the URL that does not have parameters and thus can be used to
@@ -44,14 +45,14 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * @var string
      */
-    protected $staticPrefix;
+    protected string $staticPrefix;
 
     /**
      * Variable pattern part. The static part of the pattern is the id without the prefix.
      *
      * @var string
      */
-    protected $variablePattern;
+    protected string $variablePattern;
 
     /**
      * Whether this route was changed since being last compiled.
@@ -60,7 +61,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * @var bool
      */
-    protected $needRecompile = false;
+    protected bool $needRecompile = false;
 
     /**
      * Overwrite to be able to create route without pattern.
@@ -86,7 +87,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function getRouteKey()
+    public function getRouteKey(): ?string
     {
         return $this->getId();
     }
@@ -94,7 +95,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     /**
      * Get the repository path of this url entry.
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
@@ -102,7 +103,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     /**
      * @return string the static prefix part of this route
      */
-    public function getStaticPrefix()
+    public function getStaticPrefix(): string
     {
         return $this->staticPrefix;
     }
@@ -112,7 +113,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * @return Route $this
      */
-    public function setStaticPrefix($prefix)
+    public function setStaticPrefix(string $prefix): Route
     {
         $this->staticPrefix = $prefix;
 
@@ -127,7 +128,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * @return self
      */
-    public function setContent($object)
+    public function setContent(mixed $object): self
     {
         $this->content = $object;
 
@@ -137,7 +138,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function getContent()
+    public function getContent(): ?object
     {
         return $this->content;
     }
@@ -147,7 +148,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * Prevent setting the default 'compiler_class' so that we do not persist it
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): self
     {
         return $this->addOptions($options);
     }
@@ -159,7 +160,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * @see setOptions
      */
-    public function getOption($name)
+    public function getOption($name): mixed
     {
         $option = parent::getOption($name);
         if (null === $option && 'compiler_class' === $name) {
@@ -179,7 +180,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * @see setOptions
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         $options = parent::getOptions();
         if (!\array_key_exists('compiler_class', $options)) {
@@ -201,7 +202,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * @return bool whether $name is a boolean option
      */
-    protected function isBooleanOption($name)
+    protected function isBooleanOption(string $name): bool
     {
         return \in_array($name, ['add_format_pattern', 'add_locale_pattern']);
     }
@@ -209,7 +210,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function getPath()
+    public function getPath(): string
     {
         $pattern = '';
         if ($this->getOption('add_locale_pattern')) {
@@ -234,9 +235,9 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      * When using PHPCR-ODM, make sure to persist the route before calling this
      * to have the id field initialized.
      */
-    public function setPath($pattern)
+    public function setPath($pattern): self
     {
-        if (0 !== strpos($pattern, $this->getStaticPrefix())) {
+        if (!\str_starts_with($pattern, $this->getStaticPrefix())) {
             throw new \InvalidArgumentException(sprintf(
                 'You can not set pattern "%s" for this route with a static prefix of "%s". First update the static prefix or directly use setVariablePattern.',
                 $pattern,
@@ -250,7 +251,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     /**
      * @return string the variable part of the url pattern
      */
-    public function getVariablePattern()
+    public function getVariablePattern(): string
     {
         return $this->variablePattern;
     }
@@ -260,7 +261,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * @return Route
      */
-    public function setVariablePattern($variablePattern)
+    public function setVariablePattern($variablePattern): Route
     {
         $this->variablePattern = $variablePattern;
         $this->needRecompile = true;
@@ -273,7 +274,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * Overwritten to make sure the route is recompiled if the pattern was changed
      */
-    public function compile()
+    public function compile(): CompiledRoute
     {
         if ($this->needRecompile) {
             // calling parent::setPath just to let it set compiled=null. the parent $path field is never used

--- a/src/Routing/DynamicRouter.php
+++ b/src/Routing/DynamicRouter.php
@@ -60,14 +60,14 @@ class DynamicRouter extends BaseDynamicRouter
      * is registered as a service. In both cases, the action to call on that
      * controller is appended, separated with two colons.
      */
-    public function match($url)
+    public function match($pathinfo): array
     {
-        $defaults = parent::match($url);
+        $defaults = parent::match($pathinfo);
 
         return $this->cleanDefaults($defaults);
     }
 
-    public function matchRequest(Request $request)
+    public function matchRequest(Request $request): array
     {
         $defaults = parent::matchRequest($request);
 
@@ -82,7 +82,7 @@ class DynamicRouter extends BaseDynamicRouter
      *
      * @return array the updated defaults to return for this match
      */
-    protected function cleanDefaults($defaults, Request $request = null)
+    protected function cleanDefaults($defaults, Request $request = null): array
     {
         if (null === $request) {
             $request = $this->getRequest();
@@ -125,7 +125,7 @@ class DynamicRouter extends BaseDynamicRouter
      *
      * @throws \Symfony\Component\Routing\Exception\ResourceNotFoundException
      */
-    public function getRequest()
+    public function getRequest(): Request
     {
         $currentRequest = $this->requestStack->getCurrentRequest();
         if (!$currentRequest) {

--- a/src/Routing/RedirectableRequestMatcher.php
+++ b/src/Routing/RedirectableRequestMatcher.php
@@ -40,7 +40,7 @@ class RedirectableRequestMatcher implements RequestMatcherInterface
      * If the matcher can not find a match,
      * it will try to add or remove a trailing slash to the path and match again.
      */
-    public function matchRequest(Request $request)
+    public function matchRequest(Request $request): array
     {
         try {
             return $this->decorated->matchRequest($request);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets |
| License       | MIT
| Doc PR        |

This PR makes the bundle compatible with Symfony 6.0.

I ran the [patch-type-declarations](https://wouterj.nl/2021/09/symfony-6-native-typing#when-upgrading-to-symfony-54) script to automatically add types. Due to the required return types I had to drop PHP 7.4 support.

PHP 7.4 has been removed from the tests and PHP 8.1 has been added instead. Symfony 6.0 has been included as well.

Tested with commit `cd882f0551183d9fb5e75ed56ed4a017181f1572` of the Routing library.