### PR TITLE
Add return types for sf6

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -21,13 +21,12 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: '7.4'
-                      dependencies: 'lowest'
-                    - php-version: '7.4'
-                      symfony-version: '^4.4'
-                    - php-version: '7.4'
-                      symfony-version: '^5.4'
                     - php-version: '8.0'
+                      dependencies: 'lowest'
+                    - php-version: '8.0'
+                      symfony-version: '6.0.*'
+                    - php-version: '8.1'
+                      symfony-version: '6.0.*'
 
         steps:
             - name: Checkout project

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1.0",
         "matthiasnoback/symfony-config-test": "^4.1.0",
         "doctrine/orm": "^2.5",
-        "symfony-cmf/testing": "^4.1",
+        "symfony-cmf/testing": "dev-master as 4.2.0",
         "doctrine/data-fixtures": "^1.0.0",
         "symfony/form": "^6.0",
         "symfony/translation": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         }
     ],
     "require": {
-        "php": ">=8.0.2",
-        "symfony-cmf/routing": "^2.3.2",
+        "php": "^8.0",
+        "symfony-cmf/routing": "dev-master as 3.0.0",
         "symfony/framework-bundle": "^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,28 +15,28 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": ">=8.0.2",
         "symfony-cmf/routing": "^2.3.2",
-        "symfony/framework-bundle": "^4.4 || ^5.0"
+        "symfony/framework-bundle": "^6.0"
     },
     "require-dev": {
         "jackalope/jackalope-doctrine-dbal": "^1.3",
         "doctrine/phpcr-odm": "^1.4|^2.0",
-        "symfony/phpunit-bridge": "^5.0",
+        "symfony/phpunit-bridge": "^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1.0",
         "matthiasnoback/symfony-config-test": "^4.1.0",
         "doctrine/orm": "^2.5",
-        "symfony-cmf/testing": "^4.0",
+        "symfony-cmf/testing": "^4.1",
         "doctrine/data-fixtures": "^1.0.0",
-        "symfony/form": "^4.4 || ^5.0",
-        "symfony/translation": "^4.4 || ^5.0",
-        "symfony/validator": "^4.4 || ^5.0",
-        "symfony/security-bundle": "^4.4 || ^5.0",
+        "symfony/form": "^6.0",
+        "symfony/translation": "^6.0",
+        "symfony/validator": "^6.0",
+        "symfony/security-bundle": "^6.0",
         "doctrine/doctrine-bundle": "^2.0",
-        "symfony/twig-bundle": "^4.4 || ^5.0",
+        "symfony/twig-bundle": "^6.0",
         "symfony/monolog-bundle": "^3.5",
         "doctrine/phpcr-bundle": "^2.3",
-        "symfony/serializer": "^4.4 || ^5.0",
+        "symfony/serializer": "^6.0",
         "twig/twig": "^2.4.4 || ^3.0"
     },
     "suggest": {
@@ -62,7 +62,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         }
     }
 }

--- a/src/Doctrine/Orm/ContentRepository.php
+++ b/src/Doctrine/Orm/ContentRepository.php
@@ -56,7 +56,7 @@ class ContentRepository extends DoctrineProvider implements ContentRepositoryInt
     public function getContentId($content)
     {
         if (!\is_object($content)) {
-            return;
+            return null;
         }
 
         try {
@@ -69,7 +69,7 @@ class ContentRepository extends DoctrineProvider implements ContentRepositoryInt
 
             return implode(':', [$class, reset($ids)]);
         } catch (\Exception $e) {
-            return;
+            return null;
         }
     }
 }

--- a/src/Doctrine/Orm/RedirectRoute.php
+++ b/src/Doctrine/Orm/RedirectRoute.php
@@ -78,7 +78,7 @@ class RedirectRoute extends RedirectRouteModel
     /**
      * {@inheritdoc}
      */
-    public function getPath()
+    public function getPath(): string
     {
         $pattern = parent::getPath();
         if ($this->getOption('add_trailing_slash') && '/' !== $pattern[\strlen($pattern) - 1]) {

--- a/src/Doctrine/Phpcr/ContentRepository.php
+++ b/src/Doctrine/Phpcr/ContentRepository.php
@@ -39,13 +39,13 @@ class ContentRepository extends DoctrineProvider implements ContentRepositoryInt
     public function getContentId($content)
     {
         if (!\is_object($content)) {
-            return;
+            return null;
         }
 
         try {
             return $this->getObjectManager()->getUnitOfWork()->getDocumentId($content);
         } catch (\Exception $e) {
-            return;
+            return null;
         }
     }
 }

--- a/src/Doctrine/Phpcr/RedirectRoute.php
+++ b/src/Doctrine/Phpcr/RedirectRoute.php
@@ -231,7 +231,7 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
     /**
      * {@inheritdoc}
      */
-    public function getPath()
+    public function getPath(): string
     {
         $pattern = parent::getPath();
         if ($this->getOption('add_trailing_slash') && '/' !== $pattern[\strlen($pattern) - 1]) {

--- a/src/Doctrine/Phpcr/Route.php
+++ b/src/Doctrine/Phpcr/Route.php
@@ -252,7 +252,7 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      *
      * Handle the trailing slash option.
      */
-    public function getPath()
+    public function getPath(): string
     {
         $pattern = parent::getPath();
         if ($this->getOption('add_trailing_slash') && '/' !== $pattern[\strlen($pattern) - 1]) {

--- a/src/Model/Route.php
+++ b/src/Model/Route.php
@@ -12,6 +12,7 @@
 namespace Symfony\Cmf\Bundle\RoutingBundle\Model;
 
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
+use Symfony\Component\Routing\CompiledRoute;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 use Symfony\Component\Routing\RouteCompiler;
 
@@ -147,7 +148,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * Prevent setting the default 'compiler_class' so that we do not persist it
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): static
     {
         return $this->addOptions($options);
     }
@@ -159,7 +160,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * @see setOptions
      */
-    public function getOption($name)
+    public function getOption(string $name): mixed
     {
         $option = parent::getOption($name);
         if (null === $option && 'compiler_class' === $name) {
@@ -179,7 +180,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * @see setOptions
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         $options = parent::getOptions();
         if (!\array_key_exists('compiler_class', $options)) {
@@ -209,7 +210,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function getPath()
+    public function getPath(): string
     {
         $pattern = '';
         if ($this->getOption('add_locale_pattern')) {
@@ -234,7 +235,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      * When using PHPCR-ODM, make sure to persist the route before calling this
      * to have the id field initialized.
      */
-    public function setPath($pattern)
+    public function setPath(string $pattern): static
     {
         if (0 !== strpos($pattern, $this->getStaticPrefix())) {
             throw new \InvalidArgumentException(sprintf(
@@ -273,7 +274,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
      *
      * Overwritten to make sure the route is recompiled if the pattern was changed
      */
-    public function compile()
+    public function compile(): CompiledRoute
     {
         if ($this->needRecompile) {
             // calling parent::setPath just to let it set compiled=null. the parent $path field is never used

--- a/src/Routing/DynamicRouter.php
+++ b/src/Routing/DynamicRouter.php
@@ -60,14 +60,14 @@ class DynamicRouter extends BaseDynamicRouter
      * is registered as a service. In both cases, the action to call on that
      * controller is appended, separated with two colons.
      */
-    public function match($url)
+    public function match($url): array
     {
         $defaults = parent::match($url);
 
         return $this->cleanDefaults($defaults);
     }
 
-    public function matchRequest(Request $request)
+    public function matchRequest(Request $request): array
     {
         $defaults = parent::matchRequest($request);
 

--- a/src/Routing/RedirectableRequestMatcher.php
+++ b/src/Routing/RedirectableRequestMatcher.php
@@ -40,7 +40,7 @@ class RedirectableRequestMatcher implements RequestMatcherInterface
      * If the matcher can not find a match,
      * it will try to add or remove a trailing slash to the path and match again.
      */
-    public function matchRequest(Request $request)
+    public function matchRequest(Request $request): array
     {
         try {
             return $this->decorated->matchRequest($request);


### PR DESCRIPTION
Added required return types for symfony 6.

getContentId() was also updated to return null (instead of void). The phpdoc indicated this should be string|null