### PR TITLE
Fix #478: Override getRouteKey on the Route Entity (ORM) to return th…

### DIFF
--- a/src/Doctrine/Orm/Route.php
+++ b/src/Doctrine/Orm/Route.php
@@ -57,4 +57,12 @@ class Route extends RouteModel
     {
         return $this->position;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRouteKey(): string
+    {
+        return $this->getName();
+    }
 }


### PR DESCRIPTION
…route name rather than the numeric ID.

| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / the branch of the current release for fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | #478
| License       | MIT
| Doc PR        | reference to the documentation PR, if any
