### PR TITLE
no longer register CmfRoutingBundle alias when using doctrine/persistence 3

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -40,7 +40,9 @@ jobs:
                   tools: 'composer:v2'
 
             - name: Install Symfony Flex
-              run: composer global require --no-progress --no-scripts --no-plugins symfony/flex
+              run: |
+                composer global config --no-plugins allow-plugins.symfony/flex true
+                composer global require --no-progress --no-scripts --no-plugins symfony/flex
 
             - name: Install dependencies with Composer
               uses: ramsey/composer-install@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.0.2
+-----
+
+* Do not register CmfRoutingBundle alias for ORM / PHPCR-ODM when we have doctrine/persistence 3.x as the short alias is no longer supported.
+
 3.0.1
 -----
 

--- a/src/CmfRoutingBundle.php
+++ b/src/CmfRoutingBundle.php
@@ -13,6 +13,7 @@ namespace Symfony\Cmf\Bundle\RoutingBundle;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler\DoctrinePhpcrMappingsPass;
+use Doctrine\Common\Persistence\PersistentObject;
 use Doctrine\ODM\PHPCR\Mapping\Driver\XmlDriver as PHPCRXmlDriver;
 use Doctrine\ODM\PHPCR\Version as PHPCRVersion;
 use Doctrine\ORM\EntityManagerInterface;
@@ -56,6 +57,11 @@ final class CmfRoutingBundle extends Bundle
         $container->addCompilerPass(
             $this->buildBaseCompilerPass(DoctrinePhpcrMappingsPass::class, PHPCRXmlDriver::class, 'phpcr')
         );
+        $aliasMap = [];
+        // short alias is no longer supported in doctrine/persistence 3, but keep aliasing for BC with old installations
+        if (class_exists(PersistentObject::class)) {
+            $aliasMap = ['CmfRoutingBundle' => 'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr'];
+        }
         $container->addCompilerPass(
             DoctrinePhpcrMappingsPass::createXmlMappingDriver(
                 [
@@ -64,7 +70,7 @@ final class CmfRoutingBundle extends Bundle
                 ],
                 ['cmf_routing.dynamic.persistence.phpcr.manager_name'],
                 'cmf_routing.backend_type_phpcr',
-                ['CmfRoutingBundle' => 'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr']
+                $aliasMap
             )
         );
     }
@@ -81,6 +87,11 @@ final class CmfRoutingBundle extends Bundle
         $container->addCompilerPass(
             $this->buildBaseCompilerPass(DoctrineOrmMappingsPass::class, ORMXmlDriver::class, 'orm')
         );
+        $aliasMap = [];
+        // short alias is no longer supported in doctrine/persistence 3, but keep aliasing for BC with old installations
+        if (class_exists(PersistentObject::class)) {
+            $aliasMap = ['CmfRoutingBundle' => 'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm'];
+        }
         $container->addCompilerPass(
             DoctrineOrmMappingsPass::createXmlMappingDriver(
                 [
@@ -89,7 +100,7 @@ final class CmfRoutingBundle extends Bundle
                 ],
                 ['cmf_routing.dynamic.persistence.orm.manager_name'],
                 'cmf_routing.backend_type_orm_default',
-                ['CmfRoutingBundle' => 'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm']
+                $aliasMap
             )
         );
 

--- a/src/Doctrine/Phpcr/LocaleListener.php
+++ b/src/Doctrine/Phpcr/LocaleListener.php
@@ -88,7 +88,7 @@ final class LocaleListener
 
     /**
      * Whether to make the route prepend the locale pattern if it does not
-     * have one of the allowed locals in its id.
+     * have one of the allowed locales in its id.
      */
     public function setAddLocalePattern(bool $addLocalePattern): void
     {


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | fix #485 
| License       | MIT
| Doc PR        | -
