### PR TITLE
Add mixed value like ConstraintValidatorInterface

### DIFF
--- a/src/Validator/Constraints/RouteDefaultsTwigValidator.php
+++ b/src/Validator/Constraints/RouteDefaultsTwigValidator.php
@@ -31,7 +31,7 @@ class RouteDefaultsTwigValidator extends ConstraintValidator
         $this->twig = $twig;
     }
 
-    public function validate(mixed $value, Constraint $constraint): void
+    public function validate(mixed $defaults, Constraint $constraint): void
     {
         if (!$constraint instanceof RouteDefaults) {
             throw new \InvalidArgumentException(sprintf('Expected %s, got %s', RouteDefaults::class, get_class($constraint)));

--- a/src/Validator/Constraints/RouteDefaultsTwigValidator.php
+++ b/src/Validator/Constraints/RouteDefaultsTwigValidator.php
@@ -31,7 +31,7 @@ class RouteDefaultsTwigValidator extends ConstraintValidator
         $this->twig = $twig;
     }
 
-    public function validate($defaults, Constraint $constraint)
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof RouteDefaults) {
             throw new \InvalidArgumentException(sprintf('Expected %s, got %s', RouteDefaults::class, get_class($constraint)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | the branch of the current release for fixes
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | maybe yes/no?
| Deprecations? | -
| Fixed tickets | none
| License       | MIT
| Doc PR        | none


error message symfony 7.4/8.0 changed the Symfony\Component\Validator\ConstraintValidatorInterface:validate

```
PHP Fatal error:  Declaration of
Symfony\Cmf\Bundle\RoutingBundle\Validator\Constraints\RouteDefaultsTwigValidator::validate($defaults, Symfony\Component\Validator\Constraint $constraint)
 must be compatible with
Symfony\Component\Validator\ConstraintValidatorInterface::validate(mixed $value, Symfony\Component\Validator\Constraint $constraint): void in /home/erison/project
s/SonataPageBundle/vendor/symfony-cmf/routing-bundle/src/Validator/Constraints/RouteDefaultsTwigValidator.php on line 34
```
